### PR TITLE
Move to Java17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5.0
+    gravitee: gravitee-io/gravitee@4.1.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,50 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    ":label(dependencies)"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": [
-        "orb"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": [
-        "provided",
-        "test",
-        "build",
-        "import",
-        "parent"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    },
-    {
-      "matchDepTypes": [
-        "provided",
-        "test",
-        "build",
-        "import",
-        "parent"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "semanticCommitType": "chore"
-    }
-  ]
+    "extends": ["config:base", ":label(dependencies)"],
+    "rebaseWhen": "conflicted",
+    "packageRules": [
+        {
+            "matchDatasources": ["orb"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
+            "semanticCommitType": "chore"
+        }
+    ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
     <name>Gravitee.io - JSON Validation</name>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
+        <gravitee-bom.version>6.0.4</gravitee-bom.version>
 
-        <json.version>20230227</json.version>
+        <json.version>20230618</json.version>
         <everit-json-schema.version>1.14.2</everit-json-schema.version>
 
         <maven-plugin-javadoc.version>3.5.0</maven-plugin-javadoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.0.2</version>
     </parent>
 
     <groupId>io.gravitee.json</groupId>
@@ -40,8 +40,6 @@
         <everit-json-schema.version>1.14.2</everit-json-schema.version>
 
         <maven-plugin-javadoc.version>3.5.0</maven-plugin-javadoc.version>
-        <maven-plugin-prettier.version>0.20</maven-plugin-prettier.version>
-        <maven-plugin-prettier.prettierjava.version>2.0.0</maven-plugin-prettier.prettierjava.version>
     </properties>
 
     <dependencyManagement>
@@ -110,22 +108,6 @@
                     <additionalJOption>-Xdoclint:none</additionalJOption>
                     <source>11</source>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>${maven-plugin-prettier.version}</version>
-                <configuration>
-                    <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/gravitee/json/validation/InvalidJsonException.java
+++ b/src/main/java/io/gravitee/json/validation/InvalidJsonException.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidator.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidator.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/json/validation/helper/JsonHelper.java
+++ b/src/main/java/io/gravitee/json/validation/helper/JsonHelper.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/resources/schema_nested_default_value.json
+++ b/src/test/resources/schema_nested_default_value.json
@@ -1,37 +1,31 @@
 {
-  "type": "object",
-  "properties": {
-    "name": {
-      "type": "string",
-      "default": "John Doe"
-    },
-    "address": {
-      "type": "object",
-      "properties": {
-        "city": {
-          "title": "City",
-          "type": "string",
-          "default": "Paris"
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "default": "John Doe"
+        },
+        "address": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "title": "City",
+                    "type": "string",
+                    "default": "Paris"
+                }
+            },
+            "required": ["city"],
+            "default": {
+                "city": "Lille"
+            }
+        },
+        "age": {
+            "type": "integer"
+        },
+        "citizenship": {
+            "type": "string",
+            "default": "France"
         }
-      },
-      "required": [
-        "city"
-      ],
-      "default": {
-        "city": "Lille"
-      }
     },
-    "age": {
-      "type": "integer"
-    },
-    "citizenship": {
-      "type": "string",
-      "default": "France"
-    }
-  },
-  "required": [
-    "name",
-    "citizenship",
-    "address"
-  ]
+    "required": ["name", "citizenship", "address"]
 }


### PR DESCRIPTION
**Description**

Bump dependencies and move to Java 17

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-move-to-java17-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/2.0.0-move-to-java17-SNAPSHOT/gravitee-json-validation-2.0.0-move-to-java17-SNAPSHOT.zip)
  <!-- Version placeholder end -->
