### PR TITLE
fix: update json-validation to use latest libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-bom.version>4.0.1</gravitee-bom.version>
 
-        <json.version>20230227</json.version>
+        <json.version>20230618</json.version>
         <everit-json-schema.version>1.14.2</everit-json-schema.version>
 
         <maven-plugin-javadoc.version>3.5.0</maven-plugin-javadoc.version>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Bump version of json lib to the latest.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.1-update-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/1.0.1-update-dependencies-SNAPSHOT/gravitee-json-validation-1.0.1-update-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
