### PR TITLE
fix: AM-5954 Everit location null error when using required properties and composition

### DIFF
--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -72,8 +72,8 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
                 ObjectSchema violatedSchema = (ObjectSchema) validationException.getViolatedSchema();
                 Schema schemaField = violatedSchema.getPropertySchemas().get(errorField.get());
                 if (schemaField.hasDefaultValue()) {
-                    SchemaLocation location = violatedSchema.getLocation();
-                    updateProperty(location, errorField.get(), schemaField.getDefaultValue(), safeConfigurationJson);
+                    String pointerToViolation = validationException.getPointerToViolation();
+                    updateProperty(pointerToViolation, errorField.get(), schemaField.getDefaultValue(), safeConfigurationJson);
                 } else {
                     throw new InvalidJsonException(validationException);
                 }
@@ -91,9 +91,9 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
         return safeConfigurationJson;
     }
 
-    private void updateProperty(SchemaLocation location, String key, Object value, JSONObject target) {
+    private void updateProperty(String pointerToViolation, String key, Object value, JSONObject target) {
         Arrays
-            .stream(location.toString().split("/"))
+            .stream(pointerToViolation.split("/"))
             .filter(token -> !token.equals("properties") && !token.isEmpty())
             .map(property -> {
                 if (!property.equals("#")) {

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -34,6 +34,7 @@ class JsonSchemaValidatorImplTest {
     public static final String SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES_AND_KEEP_PATTERN_PROPERTIES =
         "src/test/resources/schema_additional_properties_pattern_properties.json";
     public static final String SCHEMA_WITH_CUSTOM_REGEX = "src/test/resources/schema_custom_regex.json";
+    public static final String SCHEMA_WITH_ALLOF_AND_DEFAULT_VALUE = "src/test/resources/schema_allof_default_value.json";
 
     JsonSchemaValidator validator = new JsonSchemaValidatorImpl();
 
@@ -74,6 +75,15 @@ class JsonSchemaValidatorImplTest {
         result = validator.validate(schema, "{\"additional-property\": true, \"address\": {}}");
         assertThat(result)
             .isEqualTo("{\"additional-property\":true,\"address\":{\"city\":\"Paris\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}");
+    }
+
+    @Test
+    void should_return_updated_json_required_default_value_with_allOf() throws IOException {
+        String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_AND_DEFAULT_VALUE));
+
+        String json = "{\"citizenship\": \"FR\"}";
+        String result = validator.validate(schema, json);
+        assertThat(result).isEqualTo("{\"citizenship\":\"FR\",\"status\":\"A\"}");
     }
 
     @Test

--- a/src/test/resources/schema_allof_default_value.json
+++ b/src/test/resources/schema_allof_default_value.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["A", "B"],
+            "default": "A"
+        },
+        "citizenship": {
+            "type": "string",
+            "default": "USA"
+        }
+    },
+    "required": ["status"],
+    "allOf": [
+        {
+            "if": {
+                "properties": {
+                    "type": { "const": "A" }
+                }
+            },
+            "then": { "required": ["citizenship"] }
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**

[AM-5954](https://gravitee.atlassian.net/browse/AM-5954)

**Description**

Avoid a null reference exception when validating JSON against a schema that uses both `required` and composition elements (e.g. `allOf`). See example schema `src/test/resources/schema_allof_default_value.json`.

```
Cannot invoke "org.everit.json.schema.SchemaLocation.toString()" because "location" is null
```

Using the `pointerToViolation` in Everit's exception is safer than schema location because subschemas will not have this information.

[AM-5954]: https://gravitee.atlassian.net/browse/AM-5954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-fix-AM-5954-everit-location-null-error-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/2.0.2-fix-AM-5954-everit-location-null-error-SNAPSHOT/gravitee-json-validation-2.0.2-fix-AM-5954-everit-location-null-error-SNAPSHOT.zip)
  <!-- Version placeholder end -->
