### PR TITLE
fix: Add caching for compiled Schemas to improve performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,13 @@
             <version>${json.version}</version>
         </dependency>
 
+        <!-- Caching -->
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11993

**Description**

Introduced a caching mechanism within the JSON Schema Validator to significantly improve performance during API deployment and updates.

Previously, the validation process rebuilt the underlying JSON Schema object for every validation attempt. For APIs with complex configurations-specifically those containing a large number of Endpoint Groups (e.g., >900)-this resulted in excessive CPU usage and memory allocation. The validator now caches compiled schemas, eliminating redundant processing and drastically reducing the time required to validate complex API definitions.

**Additional context**


---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.3-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/2.0.3-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT/gravitee-json-validation-2.0.3-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/2.1.0-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT/gravitee-json-validation-2.1.0-schema-validation-cache-enabling-to-decrease-cpu-load-SNAPSHOT.zip)
  <!-- Version placeholder end -->
