### PR TITLE
feat: improve violation tolerance to use root default values for oneOf

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -109,7 +109,8 @@ The validator provides smart handling for `oneOf` schemas with automatic subsche
 
 1. **Discriminator detection**: The validator looks for `const` properties in each subschema. If the input config contains a value matching a `const`, that subschema is selected.
 2. **Default fallback**: If no discriminator is found in the config, the **first subschema** is selected by default.
-3. **Default injection**: Missing `const` values (discriminators) and missing required properties with defaults are injected from the selected subschema.
+3. **Validator pre-filling fallback**: checks whether all required properties and const constraints of the given subschema are already satisfied by the target JSON object — without injecting any defaults. With `useDefaults` enabled, the validator mutates original json in-place during validation.
+4. **Default injection**: Missing `const` values (discriminators) and missing required properties with defaults are injected from the selected subschema.
 
 ==== Example with discriminator provided
 
@@ -158,6 +159,57 @@ The validator provides smart handling for `oneOf` schemas with automatic subsche
 ----
 
 The first subschema (HTTP) is selected by default, and all its required defaults are injected, including the `const` discriminator value.
+
+==== Example with discriminator and defaults in root schema
+
+[source,json]
+----
+// Schema with oneOf and default in root
+{
+    "type": "object",
+    "properties": {
+        "partyType": {
+            "type": "string",
+            "default": "COMPANY",
+            "enum": ["COMPANY", "NATURAL"]
+        },
+        "name": {
+            "type": "string",
+            "default": "ACME"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "partyType": {
+                    "const": "NATURAL"
+                }
+            },
+            "required": ["partyType"]
+        },
+        {
+            "properties": {
+                "partyType": {
+                    "const": "COMPANY"
+                }
+            },
+            "required": ["partyType", "name"]
+        },
+        {
+            "not": {
+                "required": ["partyType"]
+            },
+            "required": ["name"]
+        }
+    ]
+}
+
+
+// Input: {}
+// Output: {"name":"ACME","partyType":"COMPANY"}
+----
+
+All required fields with default values are populated, even if they were not specified in the input data.
 
 === allOf Handling
 

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -146,7 +146,13 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
             throw new InvalidJsonException(exception);
         }
 
-        // Find and inject defaults from the matching subschema
+        // Check if the validator already injected defaults via in-place mutation.
+        // If so, we can skip manual injection to avoid redundancy.
+        boolean validatorPrefilledDefaults = validatorPrefilledDefaults(matchingSubschema, targetObject);
+        if (validatorPrefilledDefaults) {
+            return;
+        }
+
         Map<String, Object> defaults = findSubschemaDefaults(matchingSubschema, targetObject);
 
         if (defaults.isEmpty()) {
@@ -156,6 +162,57 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
         for (Map.Entry<String, Object> entry : defaults.entrySet()) {
             targetObject.put(entry.getKey(), entry.getValue());
         }
+    }
+
+    /**
+     * Checks whether all required properties and const constraints of the given subschema
+     * are already satisfied by the target JSON object — without injecting any defaults.
+     *
+     * <h3>Why this works</h3>
+     * {@code useDefaults(true)} in {@link #buildSchema} mutates {@code safeConfigurationJson}
+     * in-place during validation. Even when {@code oneOf} fails, the inner {@code allOf}
+     * subschemas are still fully evaluated and their defaults injected automatically into the live
+     * {@code JSONObject} instance.
+     *
+     * <h3>Implicit assumptions</h3>
+     * This method relies on two internal everit-json-schema behaviors that are not part
+     * of its public contract:
+     * <ul>
+     *   <li><b>Non-fail-fast allOf:</b> everit validates all {@code allOf} subschemas
+     *       regardless of intermediate failures, ensuring defaults are always injected.</li>
+     *   <li><b>In-place mutation:</b> {@code useDefaults} mutates the original
+     *       {@code JSONObject} instance rather than a defensive copy, so injected defaults
+     *       are visible outside the validation call.</li>
+     * </ul>
+     *
+     * <h3>Risk of silent regression</h3>
+     * If everit ever switches to snapshot-based validation, {@code useDefaults} would inject defaults
+     * into a copy rather than the original {@code safeConfigurationJson}. This method would then return
+     * {@code false} for previously valid input causing silent regression with no compile-time signal.
+     *
+     * @param matchingSubschema the {@code oneOf} subschema identified as the best match
+     * @param targetObject      the JSON object being validated, potentially already mutated
+     *                          by {@code useDefaults} during the preceding validation pass
+     * @return {@code true} if all required properties are present and all const constraints
+     *         are satisfied; {@code false} if manual default injection is still needed
+     */
+    private boolean validatorPrefilledDefaults(ObjectSchema matchingSubschema, JSONObject targetObject) {
+        if (!matchingSubschema.getRequiredProperties().stream().allMatch(targetObject::has)) {
+            return false; // short-circuit
+        }
+
+        return matchingSubschema
+            .getPropertySchemas()
+            .entrySet()
+            .stream()
+            .allMatch(e -> {
+                Schema unwrapped = unwrapSchema(e.getValue()); // unwrap once
+                if (!(unwrapped instanceof ConstSchema)) {
+                    return true; // non-const properties are not discriminators, skip
+                }
+                Object constVal = ((ConstSchema) unwrapped).getPermittedValue();
+                return targetObject.has(e.getKey()) && constVal.equals(targetObject.get(e.getKey()));
+            });
     }
 
     /**

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -66,6 +66,8 @@ class JsonSchemaValidatorImplTest {
     public static final String SCHEMA_WITH_ALLOF_WRAPPING_ONEOF = "src/test/resources/schema_allof_wrapping_oneof.json";
     public static final String SCHEMA_WITH_REF_TO_ONEOF = "src/test/resources/schema_real_case.json";
     public static final String SCHEMA_WITH_ONEOF_MULTIPLE_MATCH = "src/test/resources/schema_oneof_multiple_match.json";
+    public static final String SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS =
+        "src/test/resources/schema_oneof_required_with_root_defaults.json";
 
     JsonSchemaValidator validator = new JsonSchemaValidatorImpl();
 
@@ -228,6 +230,22 @@ class JsonSchemaValidatorImplTest {
         // Should inject "type": "TYPE_A" from the first subschema
         assertThat(result).contains("\"type\":\"TYPE_A\"");
         assertThat(result).contains("\"timeout\":5000");
+    }
+
+    @Test
+    void should_inject_root_default_when_discriminator_matches_subschema_oneof() throws IOException {
+        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
+        String json = "{\n" + "  \"partyType\": \"NATURAL\",\n" + "}";
+        String result = validator.validate(schema, json);
+        assertThat(result).isEqualTo("{\"name\":\"ACME\",\"partyType\":\"NATURAL\"}");
+    }
+
+    @Test
+    void should_inject_root_defaults_when_input_empty_oneof() throws IOException {
+        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
+        String json = "{\n}";
+        String result = validator.validate(schema, json);
+        assertThat(result).isEqualTo("{\"name\":\"ACME\",\"partyType\":\"COMPANY\"}");
     }
 
     @Test

--- a/src/test/resources/schema_oneof_required_with_root_defaults.json
+++ b/src/test/resources/schema_oneof_required_with_root_defaults.json
@@ -1,0 +1,38 @@
+{
+    "type": "object",
+    "properties": {
+        "partyType": {
+            "type": "string",
+            "default": "COMPANY",
+            "enum": ["COMPANY", "NATURAL"]
+        },
+        "name": {
+            "type": "string",
+            "default": "ACME"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "partyType": {
+                    "const": "NATURAL"
+                }
+            },
+            "required": ["partyType"]
+        },
+        {
+            "properties": {
+                "partyType": {
+                    "const": "COMPANY"
+                }
+            },
+            "required": ["partyType", "name"]
+        },
+        {
+            "not": {
+                "required": ["partyType"]
+            },
+            "required": ["name"]
+        }
+    ]
+}


### PR DESCRIPTION
Extends https://github.com/gravitee-io/gravitee-json-validation/pull/31 with support for oneOf and default values taken from root schema

**Issue**

https://gravitee.atlassian.net/browse/EXT-84

**Description**

The PR does not introduce new way of applying defaults, it rather relies on existing behavior of everit Json validator which (when "useDefaults" is enabled),  mutates validated JSONObject in-place during validation.
Thanks to that, the violation tolerance was extended to support use cases for oneOf and default values taken from root schema (previous [fix ](https://github.com/gravitee-io/gravitee-json-validation/pull/31) fixed things for subschemas mostly)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.0-EXT-84-improve-violation-tolerance-root-defaults-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/2.3.0-EXT-84-improve-violation-tolerance-root-defaults-SNAPSHOT/gravitee-json-validation-2.3.0-EXT-84-improve-violation-tolerance-root-defaults-SNAPSHOT.zip)
  <!-- Version placeholder end -->
