### PR TITLE
feat: migrate from everit-json-schema to networknt/json-schema-validator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.18.1
+    gravitee: gravitee-io/gravitee@5.10.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/README.adoc
+++ b/README.adoc
@@ -28,6 +28,19 @@ If validation fails and cannot be auto-corrected, an `InvalidJsonException` is t
 
 Parsed schemas are cached using Caffeine with a maximum size of 1000 entries.
 This improves performance when the same schema is used for multiple validations.
+The cache is keyed on the parsed schema node (content-based), so schemas that differ only in whitespace or key order share a single entry.
+
+[NOTE]
+====
+The schema cache is a `static` field, so it is shared by all `JsonSchemaValidatorImpl` instances loaded by the same classloader and lives for the lifetime of that classloader (not a single validator instance).
+
+In a plugin / OSGi context this has two implications:
+
+* If this library is loaded by a *shared parent* classloader, the 1000-entry cache and its eviction are global across all plugins — one plugin's schemas compete for budget with another's.
+* Cache entries survive across plugin hot-reloads when the library lives in a classloader that outlives the plugin. This is not a correctness problem (the key is the schema content, so a changed schema yields a different entry), but cached `Schema` objects keep references alive — be mindful of this if you ever store caller-supplied objects in the cache, as it could pin a stale classloader.
+
+If you need cache lifetime scoped to a single validator instance, load the library in the plugin's own classloader, or fork the field to be non-`static`.
+====
 
 === Null Values Removal
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,17 +105,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <source>21</source>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <properties>
         <gravitee-bom.version>8.3.61</gravitee-bom.version>
 
-        <json.version>20231013</json.version>
-        <everit-json-schema.version>1.14.2</everit-json-schema.version>
+        <networknt-json-schema-validator.version>2.0.1</networknt-json-schema-validator.version>
         <json-unit-assertj.version>4.1.1</json-unit-assertj.version>
 
         <gravitee.archrules.skip>true</gravitee.archrules.skip>
@@ -57,16 +56,11 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Other -->
+        <!-- JSON Schema Validation -->
         <dependency>
-            <groupId>com.github.erosb</groupId>
-            <artifactId>everit-json-schema</artifactId>
-            <version>${everit-json-schema.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${networknt-json-schema-validator.version}</version>
         </dependency>
 
         <!-- Caching -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <name>Gravitee.io - JSON Validation</name>
 
     <properties>
-        <gravitee-bom.version>6.0.62</gravitee-bom.version>
+        <gravitee-bom.version>8.3.61</gravitee-bom.version>
 
         <json.version>20231013</json.version>
         <everit-json-schema.version>1.14.2</everit-json-schema.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.json</groupId>
@@ -39,7 +39,7 @@
         <json.version>20231013</json.version>
         <everit-json-schema.version>1.14.2</everit-json-schema.version>
 
-        <maven-plugin-javadoc.version>3.12.0</maven-plugin-javadoc.version>
+        <gravitee.archrules.skip>true</gravitee.archrules.skip>
     </properties>
 
     <dependencyManagement>
@@ -110,10 +110,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-plugin-javadoc.version}</version>
                 <configuration>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
-                    <source>11</source>
+                    <source>21</source>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
         <json.version>20231013</json.version>
         <everit-json-schema.version>1.14.2</everit-json-schema.version>
+        <json-unit-assertj.version>4.1.1</json-unit-assertj.version>
 
         <gravitee.archrules.skip>true</gravitee.archrules.skip>
     </properties>
@@ -101,6 +102,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>${json-unit-assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/json/validation/InvalidJsonException.java
+++ b/src/main/java/io/gravitee/json/validation/InvalidJsonException.java
@@ -15,19 +15,13 @@
  */
 package io.gravitee.json.validation;
 
-import org.everit.json.schema.ValidationException;
-
 public class InvalidJsonException extends RuntimeException {
-
-    public InvalidJsonException(ValidationException validationException) {
-        this(getAllMessages(validationException));
-    }
 
     public InvalidJsonException(String message) {
         super(message);
     }
 
-    private static String getAllMessages(ValidationException validationException) {
-        return String.join("\n", validationException.getAllMessages());
+    public InvalidJsonException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidator.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidator.java
@@ -16,5 +16,22 @@
 package io.gravitee.json.validation;
 
 public interface JsonSchemaValidator {
+    /**
+     * Validates {@code json} against the given JSON {@code schema} and returns the JSON with recovery
+     * mutations applied: optional defaults are injected and properties that violate the schema
+     * (e.g. unexpected {@code additionalProperties}) are removed where possible. When {@code schema}
+     * is {@code null} or empty, the input is returned with only {@code null} values stripped.
+     *
+     * <p><strong>Limitation:</strong> the recovery mutations only follow <em>local</em> {@code $ref}s
+     * (JSON Pointers of the form {@code #/...}). External refs ({@code http://}, {@code file://}) and
+     * relative refs are left unresolved, so subschemas reachable only through such refs are not visited
+     * for default injection or property pruning. (Core pass/fail validation itself does resolve refs
+     * via the underlying validator; this limitation applies to the recovery step only.)
+     *
+     * @param schema the JSON schema as a string; may be {@code null} or empty to skip validation
+     * @param json   the JSON document to validate
+     * @return the (possibly mutated) JSON document serialized as a string
+     * @throws InvalidJsonException if {@code schema} or {@code json} cannot be parsed as JSON
+     */
     String validate(String schema, String json);
 }

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -108,8 +108,7 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
     }
 
     private void updateProperty(String pointerToViolation, String key, Object value, JSONObject target) {
-        Arrays
-            .stream(pointerToViolation.split("/"))
+        Arrays.stream(pointerToViolation.split("/"))
             .filter(token -> !token.equals("properties") && !token.isEmpty())
             .map(property -> {
                 if (!property.equals("#")) {
@@ -309,8 +308,7 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
     }
 
     private static Schema buildSchema(JSONObject schemaJson) {
-        return SchemaLoader
-            .builder()
+        return SchemaLoader.builder()
             .useDefaults(true)
             .addFormatValidator(new JavaRegexValidator())
             .schemaJson(schemaJson)

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -17,313 +17,569 @@ package io.gravitee.json.validation;
 
 import static io.gravitee.json.validation.helper.JsonHelper.clearNullValues;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
+import com.networknt.schema.ExecutionContext;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SchemaRegistryConfig;
+import com.networknt.schema.dialect.Dialect;
+import com.networknt.schema.dialect.Draft7;
+import com.networknt.schema.format.Format;
+import com.networknt.schema.path.PathType;
+import java.util.*;
 import java.util.regex.Pattern;
-import org.everit.json.schema.CombinedSchema;
-import org.everit.json.schema.ConstSchema;
-import org.everit.json.schema.ObjectSchema;
-import org.everit.json.schema.ReferenceSchema;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.ValidationException;
-import org.everit.json.schema.internal.RegexFormatValidator;
-import org.everit.json.schema.loader.SchemaLoader;
-import org.json.JSONObject;
+import java.util.regex.PatternSyntaxException;
 
 public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
 
-    private final Pattern errorFieldNamePattern = Pattern.compile("\\[(.*?)\\]");
-
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final long MAX_CACHE_SIZE = 1000L;
-    private static final Cache<String, Schema> SCHEMA_CACHE = Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
+
+    /**
+     * Keyed on the parsed schema node, not the raw string: JsonNode uses content-based equals/hashCode
+     * (ObjectNode compares children as a map), so schemas that differ only in whitespace or key order
+     * share one entry. The key node MUST stay read-only after insertion — mutating it would change its
+     * hashCode and corrupt the cache.
+     */
+    private static final Cache<JsonNode, Schema> SCHEMA_CACHE = Caffeine.newBuilder().maximumSize(MAX_CACHE_SIZE).build();
+
+    /**
+     * Default networknt regex format validates against ECMA-262 syntax; existing schemas use Java Pattern syntax.
+     * Override registers JavaRegexFormat for both regex and java-regex names so schema patterns compile via
+     * java.util.regex.Pattern instead of being rejected.
+     */
+    private static final Dialect DRAFT7_WITH_REGEX = Dialect.builder(Draft7.getInstance())
+        .format(new JavaRegexFormat("java-regex"))
+        .format(new JavaRegexFormat("regex"))
+        .build();
+
+    /**
+     * Factory that compiles JSON schema strings into Schema objects. Built once because:
+     *   - Binds the custom dialect above so all schemas inherit the Java-regex override.
+     *   - formatAssertionsEnabled(true) — Draft 7 treats formats as annotations by default; flip to assertions so
+     *     regex/format violations actually fail validation.
+     *   - pathType(PathType.LEGACY) — emits $.foo.bar style paths (matches old everit output, keeps navigateToTarget happy).
+     */
+    private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.withDialect(DRAFT7_WITH_REGEX, builder ->
+        builder.schemaRegistryConfig(SchemaRegistryConfig.builder().formatAssertionsEnabled(true).pathType(PathType.LEGACY).build())
+    );
 
     @Override
     public String validate(String schema, String json) {
-        // At least, validate json.
         String safeConfiguration = clearNullValues(json);
 
         if (schema != null && !schema.isEmpty()) {
-            JSONObject safeConfigurationJson = new JSONObject(safeConfiguration);
-            Schema schemaValidator = getSchemaValidator(schema);
-            // Validate json against schema when defined.
             try {
-                schemaValidator.validate(safeConfigurationJson);
-            } catch (ValidationException e) {
-                if (e.getCausingExceptions().isEmpty()) {
-                    checkAndUpdate(safeConfigurationJson, e);
-                } else {
-                    e.getCausingExceptions().forEach(cause -> checkAndUpdate(safeConfigurationJson, cause));
+                JsonNode jsonNode = MAPPER.readTree(safeConfiguration);
+                JsonNode schemaNode = MAPPER.readTree(schema);
+                Schema schemaValidator = getSchemaValidator(schemaNode);
+
+                List<com.networknt.schema.Error> errors = schemaValidator.validate(jsonNode);
+                if (!errors.isEmpty()) {
+                    jsonNode = processErrors(jsonNode, schemaNode, errors);
                 }
+
+                injectOptionalDefaults(jsonNode, schemaNode, schemaNode);
+
+                return MAPPER.writeValueAsString(jsonNode);
+            } catch (JsonProcessingException e) {
+                throw new InvalidJsonException(e.getMessage(), e);
             }
-            return safeConfigurationJson.toString();
         }
         return safeConfiguration;
     }
 
-    private Schema getSchemaValidator(String schemaDefinition) {
-        return SCHEMA_CACHE.get(schemaDefinition, key -> buildSchema(new JSONObject(key)));
+    private Schema getSchemaValidator(JsonNode schemaNode) {
+        return SCHEMA_CACHE.get(schemaNode, SCHEMA_REGISTRY::getSchema);
     }
 
-    private JSONObject checkAndUpdate(JSONObject safeConfigurationJson, ValidationException validationException) {
-        if ("required".equalsIgnoreCase(validationException.getKeyword())) {
-            Optional<String> errorField = getField(validationException);
-            if (errorField.isPresent()) {
-                ObjectSchema violatedSchema = (ObjectSchema) validationException.getViolatedSchema();
-                Schema schemaField = violatedSchema.getPropertySchemas().get(errorField.get());
-                if (schemaField.hasDefaultValue()) {
-                    String pointerToViolation = validationException.getPointerToViolation();
-                    updateProperty(pointerToViolation, errorField.get(), schemaField.getDefaultValue(), safeConfigurationJson);
-                } else {
-                    throw new InvalidJsonException(validationException);
+    /**
+     * Applies recovery mutations (default injection, additionalProperties pruning, oneOf cleanup) atomically:
+     * all work happens on a deep copy, so a partway {@link InvalidJsonException} leaves the original node
+     * untouched. Returns the mutated copy on success; the caller swaps to it for the final serialization.
+     */
+    private JsonNode processErrors(JsonNode original, JsonNode schemaNode, List<com.networknt.schema.Error> errors) {
+        JsonNode jsonNode = original.deepCopy();
+        List<String> unrecoverableErrors = new ArrayList<>();
+        Set<String> oneOfPaths = new HashSet<>();
+
+        // First pass: handle oneOf errors and collect their paths.
+        // The oneOf handler injects parent-level defaults to drive discriminator matching, then prunes the
+        // ones that don't belong to the matching subschema (see cleanupSpuriousDefaults).
+        for (com.networknt.schema.Error error : errors) {
+            if ("oneOf".equals(error.getKeyword())) {
+                oneOfPaths.add(error.getInstanceLocation().toString());
+                handleOneOfError(jsonNode, schemaNode, error, unrecoverableErrors);
+            }
+        }
+
+        // Second pass: handle remaining errors, skipping sub-errors that belong to a oneOf path
+        for (com.networknt.schema.Error error : errors) {
+            String keyword = error.getKeyword();
+            if ("oneOf".equals(keyword)) continue;
+
+            String instancePath = error.getInstanceLocation().toString();
+            String schemaFragment = error.getSchemaLocation().getFragment().toString();
+
+            // Skip errors that are sub-errors of a oneOf validation (they contain /oneOf/ in schema path)
+            // and whose instance is within a path already handled by oneOf
+            if (schemaFragment.contains("/oneOf/") && isWithinOneOfPath(instancePath, oneOfPaths)) {
+                continue;
+            }
+
+            switch (keyword) {
+                case "required" -> handleRequiredError(jsonNode, schemaNode, error, unrecoverableErrors);
+                case "additionalProperties" -> handleAdditionalPropertiesError(jsonNode, error);
+                case "allOf" -> {}
+                case "const" -> {
+                    // const errors within oneOf are handled by the oneOf handler
+                    if (!isWithinOneOfPath(instancePath, oneOfPaths)) {
+                        unrecoverableErrors.add(error.toString());
+                    }
+                }
+                default -> unrecoverableErrors.add(error.toString());
+            }
+        }
+
+        if (!unrecoverableErrors.isEmpty()) {
+            throw new InvalidJsonException(String.join("\n", unrecoverableErrors));
+        }
+
+        return jsonNode;
+    }
+
+    private boolean isWithinOneOfPath(String instancePath, Set<String> oneOfPaths) {
+        for (String oneOfPath : oneOfPaths) {
+            if (instancePath.equals(oneOfPath)) {
+                return true;
+            }
+            // Segment-aware containment: a true descendant has the oneOf path followed by a path
+            // separator ('.' for object keys, '[' for array elements in LEGACY format). A raw
+            // startsWith would falsely match a sibling like "$.httpProxy" against oneOf path "$.http".
+            if (instancePath.startsWith(oneOfPath) && instancePath.length() > oneOfPath.length()) {
+                char next = instancePath.charAt(oneOfPath.length());
+                if (next == '.' || next == '[') {
+                    return true;
                 }
             }
-        } else if ("additionalProperties".equalsIgnoreCase(validationException.getKeyword())) {
-            Optional<String> errorField = getField(validationException);
-            if (errorField.isPresent()) {
-                safeConfigurationJson.remove(errorField.get());
-            } else {
-                throw new InvalidJsonException(validationException);
-            }
-        } else if ("oneOf".equalsIgnoreCase(validationException.getKeyword())) {
-            handleOneOfError(safeConfigurationJson, validationException);
-        } else if ("allOf".equalsIgnoreCase(validationException.getKeyword())) {
-            // In some complex cases, errors are raised under the allOf keyword, but we need to work with the causing exception
-            // It is acceptable right now to not use a true recursion, and only control a one level depth
-            if (!validationException.getCausingExceptions().isEmpty()) {
-                validationException.getCausingExceptions().forEach(cause -> checkAndUpdate(safeConfigurationJson, cause));
-            } else {
-                throw new InvalidJsonException(validationException);
+        }
+        return false;
+    }
+
+    private void handleRequiredError(
+        JsonNode jsonNode,
+        JsonNode schemaNode,
+        com.networknt.schema.Error error,
+        List<String> unrecoverableErrors
+    ) {
+        Object[] arguments = error.getArguments();
+        if (arguments == null || arguments.length == 0) {
+            unrecoverableErrors.add(error.toString());
+            return;
+        }
+        String missingField = arguments[0].toString();
+        String instancePath = error.getInstanceLocation().toString();
+
+        JsonNode propertySchema = resolvePropertySchema(schemaNode, error.getSchemaLocation(), missingField);
+
+        if (propertySchema != null && propertySchema.has("default")) {
+            JsonNode defaultValue = propertySchema.get("default");
+            ObjectNode target = navigateToTarget(jsonNode, instancePath);
+            if (!target.has(missingField)) {
+                target.set(missingField, defaultValue.deepCopy());
             }
         } else {
-            throw new InvalidJsonException(validationException);
+            unrecoverableErrors.add(error.toString());
         }
-        return safeConfigurationJson;
     }
 
-    private void updateProperty(String pointerToViolation, String key, Object value, JSONObject target) {
-        Arrays.stream(pointerToViolation.split("/"))
-            .filter(token -> !token.equals("properties") && !token.isEmpty())
-            .map(property -> {
-                if (!property.equals("#")) {
-                    if (!target.has(property)) {
-                        target.put(property, new JSONObject());
-                    }
-                    return target.getJSONObject(property);
-                }
-                return target;
-            })
-            .reduce((toForgot, toKeep) -> toKeep)
-            .ifPresent(propertyToUpdate -> propertyToUpdate.put(key, value));
+    private void handleAdditionalPropertiesError(JsonNode jsonNode, com.networknt.schema.Error error) {
+        Object[] arguments = error.getArguments();
+        if (arguments == null || arguments.length == 0) {
+            return;
+        }
+        String extraField = arguments[0].toString();
+        String instancePath = error.getInstanceLocation().toString();
+        ObjectNode target = navigateToTarget(jsonNode, instancePath);
+        target.remove(extraField);
     }
 
-    private Optional<String> getField(ValidationException validationException) {
-        Matcher matcher = errorFieldNamePattern.matcher(validationException.getErrorMessage());
-        if (matcher.find()) {
-            return Optional.of(matcher.group(1));
-        }
-        return Optional.empty();
-    }
+    private void handleOneOfError(
+        JsonNode jsonNode,
+        JsonNode schemaNode,
+        com.networknt.schema.Error error,
+        List<String> unrecoverableErrors
+    ) {
+        String instancePath = error.getInstanceLocation().toString();
+        ObjectNode targetObject = navigateToTarget(jsonNode, instancePath);
 
-    private void handleOneOfError(JSONObject config, ValidationException exception) {
-        CombinedSchema combinedSchema = (CombinedSchema) exception.getViolatedSchema();
-        String pointerToViolation = exception.getPointerToViolation();
-
-        // Navigate to the target object in the config
-        JSONObject targetObject = navigateToTarget(config, pointerToViolation);
-
-        // Find the matching subschema based on discriminator, or default to the first one
-        ObjectSchema matchingSubschema = findMatchingSubschema(combinedSchema, targetObject);
-
-        if (matchingSubschema == null) {
-            throw new InvalidJsonException(exception);
-        }
-
-        // Check if the validator already injected defaults via in-place mutation.
-        // If so, we can skip manual injection to avoid redundancy.
-        boolean validatorPrefilledDefaults = validatorPrefilledDefaults(matchingSubschema, targetObject);
-        if (validatorPrefilledDefaults) {
+        JsonNode oneOfArray = findOneOfArray(schemaNode, error.getSchemaLocation());
+        if (oneOfArray == null || !oneOfArray.isArray()) {
+            unrecoverableErrors.add(error.toString());
             return;
         }
 
-        Map<String, Object> defaults = findSubschemaDefaults(matchingSubschema, targetObject);
+        // Inject property defaults from the schema containing the oneOf, so discriminator
+        // fields with defaults are present for const matching.
+        String schemaFragment = error.getSchemaLocation().getFragment().toString();
+        String parentPath = schemaFragment.contains("/") ? schemaFragment.substring(0, schemaFragment.lastIndexOf('/')) : schemaFragment;
+        if (parentPath.isEmpty()) parentPath = "/";
+        JsonNode parentSchemaNode = navigateSchemaPath(schemaNode, parentPath);
+        if (parentSchemaNode != null) {
+            injectOptionalDefaults(targetObject, schemaNode, parentSchemaNode);
+        }
 
+        JsonNode matchingSubschema = findMatchingSubschema(schemaNode, oneOfArray, targetObject);
+        if (matchingSubschema == null) {
+            unrecoverableErrors.add(error.toString());
+            return;
+        }
+
+        // Remove properties not allowed by the matching subschema. The parent-default injection above is
+        // schema-wide, so it can add fields belonging to other branches; when the matching subschema has
+        // additionalProperties: false, drop anything it doesn't define.
+        cleanupSpuriousDefaults(matchingSubschema, targetObject);
+
+        if (validatorPrefilledDefaults(schemaNode, matchingSubschema, targetObject)) {
+            return;
+        }
+
+        Map<String, JsonNode> defaults = findSubschemaDefaults(schemaNode, matchingSubschema, targetObject);
         if (defaults.isEmpty()) {
-            throw new InvalidJsonException(exception);
+            unrecoverableErrors.add(error.toString());
+            return;
         }
 
-        for (Map.Entry<String, Object> entry : defaults.entrySet()) {
-            targetObject.put(entry.getKey(), entry.getValue());
+        for (Map.Entry<String, JsonNode> entry : defaults.entrySet()) {
+            targetObject.set(entry.getKey(), entry.getValue().deepCopy());
         }
     }
 
-    /**
-     * Checks whether all required properties and const constraints of the given subschema
-     * are already satisfied by the target JSON object — without injecting any defaults.
-     *
-     * <h3>Why this works</h3>
-     * {@code useDefaults(true)} in {@link #buildSchema} mutates {@code safeConfigurationJson}
-     * in-place during validation. Even when {@code oneOf} fails, the inner {@code allOf}
-     * subschemas are still fully evaluated and their defaults injected automatically into the live
-     * {@code JSONObject} instance.
-     *
-     * <h3>Implicit assumptions</h3>
-     * This method relies on two internal everit-json-schema behaviors that are not part
-     * of its public contract:
-     * <ul>
-     *   <li><b>Non-fail-fast allOf:</b> everit validates all {@code allOf} subschemas
-     *       regardless of intermediate failures, ensuring defaults are always injected.</li>
-     *   <li><b>In-place mutation:</b> {@code useDefaults} mutates the original
-     *       {@code JSONObject} instance rather than a defensive copy, so injected defaults
-     *       are visible outside the validation call.</li>
-     * </ul>
-     *
-     * <h3>Risk of silent regression</h3>
-     * If everit ever switches to snapshot-based validation, {@code useDefaults} would inject defaults
-     * into a copy rather than the original {@code safeConfigurationJson}. This method would then return
-     * {@code false} for previously valid input causing silent regression with no compile-time signal.
-     *
-     * @param matchingSubschema the {@code oneOf} subschema identified as the best match
-     * @param targetObject      the JSON object being validated, potentially already mutated
-     *                          by {@code useDefaults} during the preceding validation pass
-     * @return {@code true} if all required properties are present and all const constraints
-     *         are satisfied; {@code false} if manual default injection is still needed
-     */
-    private boolean validatorPrefilledDefaults(ObjectSchema matchingSubschema, JSONObject targetObject) {
-        if (!matchingSubschema.getRequiredProperties().stream().allMatch(targetObject::has)) {
-            return false; // short-circuit
-        }
+    private void cleanupSpuriousDefaults(JsonNode matchingSubschema, ObjectNode targetObject) {
+        JsonNode additionalProps = matchingSubschema.get("additionalProperties");
+        if (additionalProps != null && additionalProps.isBoolean() && !additionalProps.asBoolean()) {
+            Set<String> allowedProps = new HashSet<>();
+            JsonNode properties = matchingSubschema.get("properties");
+            if (properties != null) {
+                properties.fieldNames().forEachRemaining(allowedProps::add);
+            }
 
-        return matchingSubschema
-            .getPropertySchemas()
-            .entrySet()
-            .stream()
-            .allMatch(e -> {
-                Schema unwrapped = unwrapSchema(e.getValue()); // unwrap once
-                if (!(unwrapped instanceof ConstSchema)) {
-                    return true; // non-const properties are not discriminators, skip
-                }
-                Object constVal = ((ConstSchema) unwrapped).getPermittedValue();
-                return targetObject.has(e.getKey()) && constVal.equals(targetObject.get(e.getKey()));
-            });
+            List<Pattern> allowedPatterns = new ArrayList<>();
+            JsonNode patternProperties = matchingSubschema.get("patternProperties");
+            if (patternProperties != null && patternProperties.isObject()) {
+                patternProperties
+                    .fieldNames()
+                    .forEachRemaining(patternStr -> {
+                        try {
+                            allowedPatterns.add(Pattern.compile(patternStr));
+                        } catch (PatternSyntaxException e) {
+                            // ignore invalid patterns in schema
+                        }
+                    });
+            }
+
+            List<String> toRemove = new ArrayList<>();
+            targetObject
+                .fieldNames()
+                .forEachRemaining(field -> {
+                    if (allowedProps.contains(field)) {
+                        return;
+                    }
+                    for (Pattern pattern : allowedPatterns) {
+                        if (pattern.matcher(field).find()) {
+                            return;
+                        }
+                    }
+                    toRemove.add(field);
+                });
+            toRemove.forEach(targetObject::remove);
+        }
     }
 
-    /**
-     * Finds the subschema that matches the discriminator value in the config.
-     * If no discriminator is found, returns the first subschema as default.
-     */
-    private ObjectSchema findMatchingSubschema(CombinedSchema schema, JSONObject config) {
-        ObjectSchema firstSubschema = null;
+    private JsonNode findOneOfArray(JsonNode schemaRoot, SchemaLocation schemaLocation) {
+        String fragment = schemaLocation.getFragment().toString();
+        JsonNode node = navigateSchemaPath(schemaRoot, fragment);
+        if (node != null && node.has("oneOf")) {
+            return node.get("oneOf");
+        }
+        // The schemaLocation might point directly at the oneOf keyword
+        if (node != null && node.isArray()) {
+            return node;
+        }
+        return null;
+    }
 
-        for (Schema subschema : schema.getSubschemas()) {
-            ObjectSchema objSchema = unwrapToObjectSchema(subschema);
-            if (objSchema == null) {
-                continue;
-            }
+    private JsonNode findMatchingSubschema(JsonNode schemaRoot, JsonNode oneOfArray, ObjectNode config) {
+        JsonNode firstCompatible = null;
 
-            if (firstSubschema == null) {
-                firstSubschema = objSchema;
-            }
+        for (JsonNode subschema : oneOfArray) {
+            JsonNode resolved = resolveRef(schemaRoot, subschema);
+            if (resolved == null || !resolved.has("properties")) continue;
 
-            // Check if this subschema has a const property that matches a value in config
-            for (Map.Entry<String, Schema> entry : objSchema.getPropertySchemas().entrySet()) {
+            boolean compatible = true; // input violates none of this branch's const constraints
+            boolean exactMatch = false; // input supplied a value equal to one of this branch's const
+
+            JsonNode properties = resolved.get("properties");
+            for (Map.Entry<String, JsonNode> entry : properties.properties()) {
                 String propName = entry.getKey();
-                Schema propSchema = unwrapSchema(entry.getValue());
+                JsonNode propSchema = resolveRef(schemaRoot, entry.getValue());
 
-                if (propSchema instanceof ConstSchema) {
-                    Object constValue = ((ConstSchema) propSchema).getPermittedValue();
-                    // If config has this property with the matching const value, this is our subschema
-                    if (config.has(propName) && constValue.equals(config.get(propName))) {
-                        return objSchema;
+                if (propSchema != null && propSchema.has("const") && config.has(propName)) {
+                    if (config.get(propName).equals(propSchema.get("const"))) {
+                        exactMatch = true;
+                    } else {
+                        compatible = false;
+                    }
+                }
+            }
+
+            // A branch whose discriminator the input explicitly matches wins outright.
+            if (exactMatch && compatible) {
+                return resolved;
+            }
+            // Otherwise keep the first branch the input does not contradict: covers unions without
+            // const discriminators, inputs that omit the discriminator, and free-form branches that
+            // accept the supplied value.
+            if (compatible && firstCompatible == null) {
+                firstCompatible = resolved;
+            }
+        }
+
+        // null when the input supplied a value conflicting with every branch's const: a genuine
+        // validation error. The caller surfaces the original oneOf error instead of silently
+        // injecting defaults into a mismatched branch.
+        return firstCompatible;
+    }
+
+    private boolean validatorPrefilledDefaults(JsonNode schemaRoot, JsonNode subschema, ObjectNode targetObject) {
+        JsonNode requiredArray = subschema.get("required");
+        if (requiredArray != null) {
+            for (JsonNode req : requiredArray) {
+                if (!targetObject.has(req.asText())) return false;
+            }
+        }
+
+        JsonNode properties = subschema.get("properties");
+        if (properties != null) {
+            for (Map.Entry<String, JsonNode> entry : properties.properties()) {
+                JsonNode propSchema = resolveRef(schemaRoot, entry.getValue());
+                if (propSchema != null && propSchema.has("const")) {
+                    JsonNode constVal = propSchema.get("const");
+                    if (!targetObject.has(entry.getKey()) || !constVal.equals(targetObject.get(entry.getKey()))) {
+                        return false;
                     }
                 }
             }
         }
 
-        // No discriminator found in config, return the first subschema as default
-        return firstSubschema;
+        return true;
     }
 
-    /**
-     * Finds all defaults to inject for a given subschema:
-     * - const values for properties not in config (discriminators)
-     * - default values for required properties not in config
-     */
-    private Map<String, Object> findSubschemaDefaults(ObjectSchema subschema, JSONObject config) {
-        Map<String, Object> result = new HashMap<>();
-        Set<String> requiredProps = new HashSet<>(subschema.getRequiredProperties());
+    private Map<String, JsonNode> findSubschemaDefaults(JsonNode schemaRoot, JsonNode subschema, ObjectNode config) {
+        Map<String, JsonNode> result = new LinkedHashMap<>();
+        Set<String> requiredProps = new HashSet<>();
 
-        for (Map.Entry<String, Schema> entry : subschema.getPropertySchemas().entrySet()) {
+        JsonNode requiredArray = subschema.get("required");
+        if (requiredArray != null) {
+            for (JsonNode r : requiredArray) requiredProps.add(r.asText());
+        }
+
+        JsonNode properties = subschema.get("properties");
+        if (properties == null) return result;
+
+        for (Map.Entry<String, JsonNode> entry : properties.properties()) {
             String propName = entry.getKey();
-            Schema propSchema = unwrapSchema(entry.getValue());
+            if (config.has(propName)) continue;
 
-            // Skip if already in config
-            if (config.has(propName)) {
-                continue;
-            }
+            JsonNode propSchema = resolveRef(schemaRoot, entry.getValue());
+            if (propSchema == null) continue;
 
-            // Inject const values (discriminators)
-            if (propSchema instanceof ConstSchema) {
-                result.put(propName, ((ConstSchema) propSchema).getPermittedValue());
-            }
-            // Inject default values for required properties
-            else if (requiredProps.contains(propName) && propSchema != null && propSchema.hasDefaultValue()) {
-                result.put(propName, propSchema.getDefaultValue());
+            if (propSchema.has("const")) {
+                result.put(propName, propSchema.get("const"));
+            } else if (requiredProps.contains(propName) && propSchema.has("default")) {
+                result.put(propName, propSchema.get("default"));
             }
         }
 
         return result;
     }
 
-    private Schema unwrapSchema(Schema schema) {
-        if (schema instanceof ReferenceSchema) {
-            return ((ReferenceSchema) schema).getReferredSchema();
-        }
-        return schema;
+    private JsonNode resolveRef(JsonNode schemaRoot, JsonNode node) {
+        return resolveRef(schemaRoot, node, new HashSet<>());
     }
 
-    private ObjectSchema unwrapToObjectSchema(Schema schema) {
-        Schema unwrapped = unwrapSchema(schema);
-        return (unwrapped instanceof ObjectSchema) ? (ObjectSchema) unwrapped : null;
+    // visited guards against $ref cycles (e.g. a -> b -> a) which would otherwise StackOverflow.
+    private JsonNode resolveRef(JsonNode schemaRoot, JsonNode node, Set<String> visited) {
+        if (node == null) return null;
+        if (!node.has("$ref")) return node;
+
+        String ref = node.get("$ref").asText();
+        if (!visited.add(ref)) return null;
+
+        if ("#".equals(ref)) {
+            return resolveRef(schemaRoot, schemaRoot, visited);
+        }
+
+        if (ref.startsWith("#/")) {
+            String[] parts = ref.substring(2).split("/");
+            JsonNode current = schemaRoot;
+            for (String part : parts) {
+                String unescaped = part.replace("~1", "/").replace("~0", "~");
+                current = current.get(unescaped);
+                if (current == null) return null;
+            }
+            return resolveRef(schemaRoot, current, visited);
+        }
+        return node;
     }
 
-    private JSONObject navigateToTarget(JSONObject root, String pointer) {
-        if ("#".equals(pointer) || pointer.isEmpty()) {
-            return root;
-        }
-        String[] parts = pointer.replaceFirst("^#/?", "").split("/");
-        JSONObject current = root;
+    private JsonNode navigateSchemaPath(JsonNode schemaRoot, String path) {
+        if (path == null || path.isEmpty() || "/".equals(path)) return schemaRoot;
+
+        String normalized = path.startsWith("/") ? path.substring(1) : path;
+        String[] parts = normalized.split("/");
+        JsonNode current = schemaRoot;
         for (String part : parts) {
-            if (!part.isEmpty() && current.has(part)) {
-                current = current.getJSONObject(part);
+            if (part.isEmpty()) continue;
+            if (current == null) return null;
+            // Handle array indices
+            if (current.isArray()) {
+                try {
+                    int index = Integer.parseInt(part);
+                    current = current.get(index);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            } else {
+                String unescaped = part.replace("~1", "/").replace("~0", "~");
+                current = current.get(unescaped);
             }
         }
         return current;
     }
 
-    private static Schema buildSchema(JSONObject schemaJson) {
-        return SchemaLoader.builder()
-            .useDefaults(true)
-            .addFormatValidator(new JavaRegexValidator())
-            .schemaJson(schemaJson)
-            .draftV7Support()
-            .build()
-            .load()
-            .build();
+    // Splits on '.' — property names containing '.' are not supported by the LEGACY path format.
+    private ObjectNode navigateToTarget(JsonNode root, String instancePath) {
+        if (!(root instanceof ObjectNode objectNode)) {
+            throw new InvalidJsonException("Expected JSON object at path: " + instancePath);
+        }
+        if (instancePath == null || instancePath.isEmpty() || "$".equals(instancePath)) {
+            return objectNode;
+        }
+
+        // Handle legacy path format like "$.http.endpoint" or just path without $
+        String normalized = instancePath.startsWith("$.") ? instancePath.substring(2) : instancePath;
+        if (normalized.startsWith("$")) normalized = normalized.substring(1);
+        if (normalized.isEmpty()) return objectNode;
+
+        String prepared = normalized.replace("[", ".[");
+        String[] parts = prepared.split("\\.");
+        JsonNode current = root;
+        for (String part : parts) {
+            if (part.isEmpty()) continue;
+            if (part.startsWith("[") && part.endsWith("]")) {
+                if (!current.isArray()) {
+                    throw new InvalidJsonException("Cannot navigate to path '" + instancePath + "': expected array at '" + part + "'");
+                }
+                try {
+                    int index = Integer.parseInt(part.substring(1, part.length() - 1));
+                    if (index < 0 || index >= current.size()) {
+                        throw new InvalidJsonException(
+                            "Cannot navigate to path '" + instancePath + "': index out of bounds '" + part + "'"
+                        );
+                    }
+                    current = current.get(index);
+                } catch (NumberFormatException e) {
+                    throw new InvalidJsonException("Cannot navigate to path '" + instancePath + "': invalid array index '" + part + "'");
+                }
+            } else {
+                if (!current.isObject() || !current.has(part)) {
+                    throw new InvalidJsonException("Cannot navigate to path '" + instancePath + "': missing segment '" + part + "'");
+                }
+                current = current.get(part);
+            }
+        }
+        if (current instanceof ObjectNode target) {
+            return target;
+        }
+        throw new InvalidJsonException("Path '" + instancePath + "' does not resolve to a JSON object");
     }
 
-    private static class JavaRegexValidator extends RegexFormatValidator {
+    private JsonNode resolvePropertySchema(JsonNode schemaRoot, SchemaLocation schemaLocation, String propertyName) {
+        String fragment = schemaLocation.getFragment().toString();
+        // The schema location for "required" errors points to the "required" keyword itself (e.g. /required or /allOf/0/then/required).
+        // Navigate to the parent object that contains both "required" and "properties".
+        if (fragment.endsWith("/required")) {
+            fragment = fragment.substring(0, fragment.length() - "/required".length());
+            if (fragment.isEmpty()) fragment = "/";
+        }
+        JsonNode schemaNode = navigateSchemaPath(schemaRoot, fragment);
+        if (schemaNode == null) return null;
 
-        // Just for retro-compatibility with old validator
+        JsonNode props = schemaNode.get("properties");
+        if (props != null && props.has(propertyName)) {
+            return resolveRef(schemaRoot, props.get(propertyName));
+        }
+        return null;
+    }
+
+    // schemaRoot is the document root used to resolve "#/..." $refs; schemaNode is the (sub)schema being walked.
+    private void injectOptionalDefaults(JsonNode jsonNode, JsonNode schemaRoot, JsonNode schemaNode) {
+        if (!(jsonNode instanceof ObjectNode objectNode)) return;
+
+        JsonNode resolved = resolveRef(schemaRoot, schemaNode);
+        if (resolved == null) return;
+
+        JsonNode properties = resolved.get("properties");
+        if (properties == null) return;
+
+        for (Map.Entry<String, JsonNode> entry : properties.properties()) {
+            String propName = entry.getKey();
+            JsonNode propSchema = resolveRef(schemaRoot, entry.getValue());
+            if (propSchema == null) continue;
+
+            if (!objectNode.has(propName)) {
+                if (propSchema.has("default")) {
+                    objectNode.set(propName, propSchema.get("default").deepCopy());
+                }
+            } else {
+                JsonNode child = objectNode.get(propName);
+                if (child.isObject() && propSchema.has("properties")) {
+                    injectOptionalDefaults(child, schemaRoot, propSchema);
+                } else if (child.isArray() && propSchema.has("items")) {
+                    JsonNode itemsSchema = resolveRef(schemaRoot, propSchema.get("items"));
+                    if (itemsSchema != null) {
+                        for (JsonNode element : child) {
+                            if (element.isObject()) {
+                                injectOptionalDefaults(element, schemaRoot, itemsSchema);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private record JavaRegexFormat(String name) implements Format {
         @Override
-        public String formatName() {
-            return "java-regex";
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean matches(ExecutionContext executionContext, String value) {
+            try {
+                Pattern.compile(value);
+                return true;
+            } catch (PatternSyntaxException e) {
+                return false;
+            }
         }
     }
 }

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -17,9 +17,11 @@ package io.gravitee.json.validation;
 
 import static io.gravitee.json.validation.helper.JsonHelper.clearNullValues;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -38,7 +40,9 @@ import java.util.regex.PatternSyntaxException;
 
 public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.builder()
+        .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+        .build();
     private static final long MAX_CACHE_SIZE = 1000L;
 
     /**
@@ -72,7 +76,7 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
 
     @Override
     public String validate(String schema, String json) {
-        String safeConfiguration = clearNullValues(json);
+        String safeConfiguration = clearNullValues(MAPPER, json);
 
         if (schema != null && !schema.isEmpty()) {
             try {

--- a/src/main/java/io/gravitee/json/validation/helper/JsonHelper.java
+++ b/src/main/java/io/gravitee/json/validation/helper/JsonHelper.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.json.validation.helper;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
@@ -23,15 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class JsonHelper {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    static {
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
-
     private JsonHelper() {}
 
-    public static String clearNullValues(String jsonPayload) {
+    public static String clearNullValues(ObjectMapper objectMapper, String jsonPayload) {
         if (jsonPayload == null) {
             return null;
         }

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -20,13 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.networknt.schema.Schema;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.everit.json.schema.Schema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -71,6 +71,15 @@ class JsonSchemaValidatorImplTest {
     public static final String SCHEMA_WITH_ONEOF_MULTIPLE_MATCH = "src/test/resources/schema_oneof_multiple_match.json";
     public static final String SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS =
         "src/test/resources/schema_oneof_required_with_root_defaults.json";
+    public static final String SCHEMA_WITH_ROOT_REF = "src/test/resources/schema_root_ref.json";
+    public static final String SCHEMA_MULTIPLE_REQUIRED_NO_DEFAULTS = "src/test/resources/schema_multiple_required_no_defaults.json";
+    public static final String SCHEMA_DEEPLY_NESTED_DEFAULTS = "src/test/resources/schema_deeply_nested_defaults.json";
+    public static final String SCHEMA_NESTED_ADDITIONAL_PROPERTIES = "src/test/resources/schema_nested_additional_properties.json";
+    public static final String SCHEMA_ONEOF_DISCRIMINATOR_WITH_REQUIRED =
+        "src/test/resources/schema_oneof_discriminator_with_required.json";
+    public static final String SCHEMA_ONEOF_NO_DISCRIMINATOR = "src/test/resources/schema_oneof_no_discriminator.json";
+    public static final String SCHEMA_ONEOF_MIXED_CONST_FREEFORM = "src/test/resources/schema_oneof_mixed_const_freeform.json";
+    public static final String SCHEMA_ONEOF_PATTERN_PROPERTIES = "src/test/resources/schema_oneof_pattern_properties.json";
 
     JsonSchemaValidator validator = new JsonSchemaValidatorImpl();
 
@@ -79,531 +88,884 @@ class JsonSchemaValidatorImplTest {
         clearCache();
     }
 
-    @Test
-    void should_return_json_content_when_valid() throws IOException {
-        String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = """
-            { "name": "John",  "age": 30 }""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(json);
-    }
-
-    @Test
-    void should_throw_exception_when_invalid() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
-
-        assertThatThrownBy(() ->
-            validator.validate(
-                schema,
-                """
-                { "age": 30, "citizenship": "FR" }"""
-            )
-        )
-            .isInstanceOf(InvalidJsonException.class)
-            .hasMessage("#: required key [name] not found");
-
-        assertThatThrownBy(() ->
-            validator.validate(
-                schema,
-                """
-                { "name": "John", "age": true }"""
-            )
-        )
-            .isInstanceOf(InvalidJsonException.class)
-            .hasMessage("#/age: expected type: Integer, found: Boolean");
-    }
-
-    @Test
-    void should_return_updated_json_required_default_value_missing() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
-
-        String json = """
-            { "name": "John",  "age": 30 }""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"citizenship":"USA","name":"John","age":30}"""
-        );
-
-        schema = Files.readString(Path.of(SCHEMA_WITH_NESTED_DEFAULT_VALUE));
-        result = validator.validate(schema, "{\"additional-property\": true}");
-        assertThatJson(result).isEqualTo(
-            """
-            {"additional-property":true,"address":{"city":"Lille"},"citizenship":"France","name":"John Doe"}"""
-        );
-
-        result = validator.validate(
-            schema,
-            """
-            {"additional-property": true, "address": {}}"""
-        );
-        assertThatJson(result).isEqualTo(
-            """
-            {"additional-property":true,"address":{"city":"Paris"},"citizenship":"France","name":"John Doe"}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_required_default_value_with_allOf() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_AND_DEFAULT_VALUE));
-
-        String json = """
-            {"citizenship": "FR"}""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"citizenship":"FR","status":"A"}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_required_default_value_with_oneOf() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_AND_DEFAULT_VALUE));
-
-        // Missing "protocol" in nested "http" object - should inject default "HTTP1"
-        String json = """
-            {
-                "http": {
-                    "keepAlive": true
-                }
-            }
-            """;
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"http":{"protocol":"HTTP1","keepAlive":true}}"""
-        );
-    }
-
-    @Test
-    void should_throw_exception_when_oneOf_has_no_common_required_defaults() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_NO_COMMON_DEFAULT));
-
-        // No common required properties between subschemas, should throw
-        assertThatThrownBy(() -> validator.validate(schema, "{}")).isInstanceOf(InvalidJsonException.class);
-    }
-
-    @Test
-    void should_only_inject_common_required_defaults_in_oneOf() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_PARTIAL_REQUIRED));
-
-        // "common" is required in both subschemas -> should be injected
-        // "onlyInFirst" is required only in first subschema -> should NOT be injected
-        // "onlyInSecond" is required only in second subschema -> should NOT be injected
-        String json = """
-            { "onlyInFirst": "provided" }
-            """;
-        String result = validator.validate(schema, json);
-
-        // Only "common" should be added, not "onlyInSecond"
-        assertThatJson(result).isEqualTo(
-            """
-            {"common":"defaultCommon","onlyInFirst":"provided"}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_when_allOf_wraps_oneOf_with_missing_required_defaults() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_WRAPPING_ONEOF));
-
-        // "readTimeout" is required in both oneOf subschemas and has a default value
-        // The oneOf is wrapped inside an allOf, so we need to traverse the causingExceptions
-        String json = """
-            { "http": { "version": "HTTP_1_1" } }
-            """;
-        String result = validator.validate(schema, json);
-
-        // "readTimeout" should be injected with its default value 10000
-        assertThatJson(result).isEqualTo(
-            """
-            {"http":{"connectTimeout":5000,"readTimeout":10000,"version":"HTTP_1_1"}}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_when_ref_to_oneof_with_missing_required_defaults() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_REF_TO_ONEOF));
-
-        // "readTimeout" is missing but has a default value in the schema
-        // The schema uses $ref to a definition containing oneOf with "type": "object"
-        // This creates an internal allOf (type + oneOf) that wraps the oneOf error
-        String json = """
-            { "http": { "connectTimeout": 5000 } }
-            """;
-        String result = validator.validate(schema, json);
-
-        // "readTimeout" should be injected with its default value 10000
-        assertThatJson(result).isEqualTo(
-            """
-            {"http":{"connectTimeout":5000,"readTimeout":10000,"version":"HTTP_1_1"}}"""
-        );
-    }
-
-    @Test
-    void should_default_to_first_subschema_when_multiple_oneOf_match() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_MULTIPLE_MATCH));
-
-        // When no "type" is provided, both subschemas would match (they only differ by const value)
-        // The validator should default to the first subschema and inject its const value
-        String json = """
-            { "config": { "timeout": 5000 } }
-            """;
-        String result = validator.validate(schema, json);
-
-        // Should inject "type": "TYPE_A" from the first subschema
-        assertThatJson(result).isEqualTo(
-            """
-            {"config":{"timeout":5000,"type":"TYPE_A"}}"""
-        );
-    }
-
-    @Test
-    void should_inject_root_default_when_discriminator_matches_subschema_oneof() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
-        String json = """
-            { "partyType": "NATURAL" }""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"name":"ACME","partyType":"NATURAL"}"""
-        );
-    }
-
-    @Test
-    void should_inject_root_defaults_when_input_empty_oneof() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
-        String json = "{\n}";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"name":"ACME","partyType":"COMPANY"}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_with_additional_properties_removed() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES));
-
-        String json = """
-            { "name": "John", "age": 30, "unknown": 30 }""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"name":"John","age":30}"""
-        );
-    }
-
-    @Test
-    void should_return_updated_json_with_additional_properties_removed_keeping_pattern_properties() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES_AND_KEEP_PATTERN_PROPERTIES));
-
-        String json = """
-            { "name": "John", "to-keep": "value", "age": 30, "unknown": 30 }""";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo(
-            """
-            {"name":"John","to-keep":"value","age":30}"""
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "regex", "java-regex" })
-    public void should_return_valid_json_with_schema_using_custom_java_regex(String regexFormat) throws Exception {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
-        String json = "{ \"name\": \"^.*[A-Za-z]\\\\d*$\", \"valid\": true }";
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo("{\"valid\":true,\"name\":\"^.*[A-Za-z]\\\\d*$\"}");
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "regex", "java-regex" })
-    public void should_reject_invalid_json_due_to_invalid_regex(String regexFormat) throws Exception {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
-
-        assertThatThrownBy(() ->
-            validator.validate(
-                schema,
-                """
-                { "name": "( INVALID regex", "valid": true }"""
-            )
-        )
-            .isInstanceOf(InvalidJsonException.class)
-            .hasMessage("#/name: [( INVALID regex] is not a valid regular expression");
-    }
-
-    // ---------------- Cache behavior tests ----------------
-
-    @Test
-    void should_cache_schema_once_for_repeated_validation() throws Exception {
-        String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = """
-            { "name": "John", "age": 30 }""";
-
-        assertThat(cacheSize()).isZero();
-
-        // First validation builds and caches the schema
-        validator.validate(schema, json);
-        assertThat(cacheSize()).isOne();
-
-        // Second validation with same schema should reuse cache (still 1)
-        validator.validate(schema, json);
-        assertThat(cacheSize()).isOne();
-    }
-
-    @Test
-    void should_cache_two_entries_for_two_different_schemas() throws Exception {
-        String schema1 = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String schema2 = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
-        String json = """
-            { "name": "John", "age": 30 }""";
-
-        validator.validate(schema1, json);
-        assertThat(cacheSize()).isOne();
-
-        validator.validate(schema2, json);
-        assertThat(cacheSize()).isEqualTo(2);
-    }
-
-    @Test
-    void should_not_cache_when_schema_is_empty_or_null() {
-        // Empty schema string
-        validator.validate("", "{ } ");
-        assertThat(cacheSize()).isZero();
-
-        // Null schema
-        validator.validate(null, "{ } ");
-        assertThat(cacheSize()).isZero();
-    }
-
-    @Test
-    void should_cache_once_under_concurrency() throws Exception {
-        String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = """
-            { "name": "John", "age": 30 }""";
-
-        int threads = 8;
-        ExecutorService es = Executors.newFixedThreadPool(threads);
-        CountDownLatch start = new CountDownLatch(1);
-        CountDownLatch done = new CountDownLatch(threads);
-        java.util.concurrent.atomic.AtomicReference<Throwable> errorReference = new java.util.concurrent.atomic.AtomicReference<>();
-
-        for (int i = 0; i < threads; i++) {
-            es.submit(() -> {
-                try {
-                    start.await(5, java.util.concurrent.TimeUnit.SECONDS);
-                    validator.validate(schema, json);
-                } catch (Throwable e) {
-                    // Catch Throwable to handle Errors too, not just Exceptions
-                    errorReference.set(e);
-                } finally {
-                    done.countDown();
-                }
-            });
-        }
-
-        start.countDown();
-        boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
-        es.shutdownNow();
-
-        assertThat(finished).as("Test threads timed out").isTrue();
-        assertThat(errorReference.get()).as("Validation failed in a concurrent thread").isNull();
-        assertThat(cacheSize()).isOne();
-    }
-
-    // ---------------- Characterization tests (migration safety net) ----------------
-
-    @Test
-    void should_throw_when_multiple_required_fields_missing_without_defaults() throws IOException {
-        String schema = Files.readString(Path.of("src/test/resources/schema_multiple_required_no_defaults.json"));
-
-        assertThatThrownBy(() -> validator.validate(schema, "{}"))
-            .isInstanceOf(InvalidJsonException.class)
-            .satisfies(ex -> {
-                String message = ex.getMessage();
-                // Current behavior: at least one missing required field is reported
-                assertThat(message).containsAnyOf("firstName", "lastName", "email");
-            });
-    }
-
-    @Test
-    void should_inject_defaults_in_deeply_nested_schema() throws IOException {
-        String schema = Files.readString(Path.of("src/test/resources/schema_deeply_nested_defaults.json"));
-
-        // Empty object — all defaults at 3+ levels should be injected
-        String result = validator.validate(schema, "{}");
-        assertThatJson(result).isEqualTo("""
-                {"topField":"top-default","level1":{"level2":{"level3":{"value":"deep-default"}}}}
-                """);
-    }
-
-    @Test
-    void should_inject_defaults_at_deepest_level_when_parents_exist() throws IOException {
-        String schema = Files.readString(Path.of("src/test/resources/schema_deeply_nested_defaults.json"));
-
-        // Parents exist but deepest value is missing
-        String json = """
-            {
-                "level1": {
-                    "level2": {
-                        "level3": {}
-                    }
-                },
-                "topField": "provided"
-            }
-            """;
-        String result = validator.validate(schema, json);
-        assertThatJson(result).isEqualTo("""
-                {"topField":"provided","level1":{"level2":{"level3":{}}},"level3":{"value":"deep-default"},"level2":{}}
-                """);
-    }
-
-    @Test
-    void should_inject_defaults_when_ref_to_oneof_with_second_subschema_discriminator() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_REF_TO_ONEOF));
-
-        // Discriminator for second subschema (HTTP_2) provided
-        // "readTimeout" and "connectTimeout" are missing but have defaults via $ref
-        String json = """
-            {
-                "http": {
-                    "version": "HTTP_2"
-                }
-            }
-            """;
-        String result = validator.validate(schema, json);
-
-        // Should keep the discriminator value and inject defaults from $ref definitions
-        assertThatJson(result).isEqualTo("""
-                {"http":{"readTimeout":10000,"connectTimeout":3000,"version":"HTTP_2"}}
-                """);
-    }
-
-    @Test
-    void should_not_remove_additional_properties_in_nested_object() throws IOException {
-        // Current behavior: additionalProperties removal only works at root level.
-        // Nested additional properties are NOT removed — they remain in the output.
-        String schema = Files.readString(Path.of("src/test/resources/schema_nested_additional_properties.json"));
-
-        String json = """
-            {
-                "name": "test",
-                "config": {
-                    "timeout": 5000,
-                    "retries": 3,
-                    "unknownField": "should-be-removed"
-                }
-            }
-            """;
-        String result = validator.validate(schema, json);
-        // Note: unknownField is NOT removed in nested objects (current limitation)
-        assertThatJson(result).isEqualTo("""
-                {"name":"test","config":{"retries":3,"unknownField":"should-be-removed","timeout":5000}}
-                """);
-    }
-
-    @Test
-    void should_clear_nulls_and_inject_defaults() throws IOException {
-        String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
-
-        // "citizenship" is null (will be cleared) and has a default "USA"
-        // "name" is provided, "age" is null (will be cleared, not required)
-        String json = """
-            {
-                "name": "John",
-                "age": null,
-                "citizenship": null
-            }
-            """;
-        String result = validator.validate(schema, json);
-
-        // null values should be cleared first, then defaults injected
-        assertThatJson(result).isEqualTo("""
-                {"citizenship":"USA","name":"John"}
-                """);
-    }
-
-    // ---------------- OneOf with discriminator and required fields ----------------
+    // -------------------------------------------------------------------------
+    // Basic validation
+    // -------------------------------------------------------------------------
 
     @Nested
-    class OneOfDiscriminatorWithRequiredFields {
-
-        private static final String SCHEMA_PATH = "src/test/resources/schema_oneof_discriminator_with_required.json";
-
-        /*
-         * Schema structure:
-         * - HTTP Endpoint (first): type=HTTP (const), connectTimeout (default 5000), readTimeout (default 10000), keepAliveTimeout (default 30000)
-         *   Required: type, connectTimeout, readTimeout, keepAliveTimeout
-         *
-         * - GRPC Endpoint (second): type=GRPC (const), port (default 443), connectTimeout (default 3000), readTimeout (default 5000)
-         *   Required: type, connectTimeout, readTimeout, port
-         *
-         * Common required: type, connectTimeout, readTimeout
-         * HTTP-only required: keepAliveTimeout
-         * GRPC-only required: port
-         */
+    class BasicValidation {
 
         @Test
-        void should_choose_first_subschema_and_inject_required_defaults_when_no_discriminator() throws IOException {
-            String schema = Files.readString(Path.of(SCHEMA_PATH));
-
-            // No discriminator (type) provided, no required fields
-            // Should default to first subschema (HTTP) and inject its const + required defaults
+        void should_return_json_content_when_valid() throws IOException {
+            String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
             String json = """
-                {
-                    "endpoint": {}
-                }
-                """;
+                { "name": "John",  "age": 30 }""";
             String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(json);
+        }
 
-            // Should have HTTP type (const from first subschema)
+        @Test
+        void should_throw_when_required_field_missing() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+
+            assertThatThrownBy(() ->
+                validator.validate(
+                    schema,
+                    """
+                    { "age": 30, "citizenship": "FR" }"""
+                )
+            )
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessage("$: required property 'name' not found");
+        }
+
+        @Test
+        void should_throw_when_field_has_wrong_type() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+
+            assertThatThrownBy(() ->
+                validator.validate(
+                    schema,
+                    """
+                    { "name": "John", "age": true }"""
+                )
+            )
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessage("$.age: boolean found, integer expected");
+        }
+
+        @Test
+        void should_throw_when_multiple_required_fields_missing_without_defaults() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_MULTIPLE_REQUIRED_NO_DEFAULTS));
+
+            assertThatThrownBy(() -> validator.validate(schema, "{}"))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessage(
+                    """
+                    $: required property 'firstName' not found
+                    $: required property 'lastName' not found
+                    $: required property 'email' not found"""
+                );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Default value injection
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class DefaultInjection {
+
+        @Test
+        void should_inject_simple_default_value() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+
+            String json = """
+                { "name": "John",  "age": 30 }""";
+            String result = validator.validate(schema, json);
             assertThatJson(result).isEqualTo(
                 """
-                {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+                {"citizenship":"USA","name":"John","age":30}"""
             );
         }
 
         @Test
-        void should_inject_required_defaults_when_first_subschema_discriminator_provided() throws IOException {
-            String schema = Files.readString(Path.of(SCHEMA_PATH));
+        void should_inject_nested_defaults_from_empty_object() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_NESTED_DEFAULT_VALUE));
 
-            // Discriminator for first subschema (HTTP) provided
-            // Should inject HTTP required defaults
+            String result = validator.validate(schema, "{\"additional-property\": true}");
+            assertThatJson(result).isEqualTo(
+                """
+                {"additional-property":true,"address":{"city":"Lille"},"citizenship":"France","name":"John Doe"}"""
+            );
+        }
+
+        @Test
+        void should_inject_nested_defaults_when_parent_exists_but_child_missing() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_NESTED_DEFAULT_VALUE));
+
+            String result = validator.validate(
+                schema,
+                """
+                {"additional-property": true, "address": {}}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"additional-property":true,"address":{"city":"Paris"},"citizenship":"France","name":"John Doe"}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_with_allOf() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_AND_DEFAULT_VALUE));
+
+            String json = """
+                {"citizenship": "FR"}""";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"citizenship":"FR","status":"A"}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_when_root_schema_is_a_ref() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ROOT_REF));
+            String result = validator.validate(schema, "{}");
+            assertThatJson(result).isEqualTo(
+                """
+                {"timeout":5000}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_in_deeply_nested_schema() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_DEEPLY_NESTED_DEFAULTS));
+
+            String result = validator.validate(schema, "{}");
+            assertThatJson(result).isEqualTo(
+                """
+                {"topField":"top-default","level1":{"level2":{"level3":{"value":"deep-default"}}}}
+                """
+            );
+        }
+
+        @Test
+        void should_inject_defaults_at_deepest_level_when_parents_exist() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_DEEPLY_NESTED_DEFAULTS));
+
             String json = """
                 {
-                    "endpoint": {
-                        "type": "HTTP"
+                    "level1": {
+                        "level2": {
+                            "level3": {}
+                        }
+                    },
+                    "topField": "provided"
+                }
+                """;
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {
+                  "topField":"provided",
+                  "level1":{
+                    "level2":{
+                      "level3":{"value":"deep-default"}
+                    }
+                  }
+                }
+                """
+            );
+        }
+
+        @Test
+        void should_inject_optional_defaults_inside_array_elements() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "endpoints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "url": { "type": "string" },
+                          "weight": { "type": "integer", "default": 1 },
+                          "backup": { "type": "boolean", "default": false }
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            String result = validator.validate(
+                schema,
+                """
+                {"endpoints": [{"url": "http://a"}, {"url": "http://b", "weight": 5}]}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"endpoints":[{"url":"http://a","weight":1,"backup":false},{"url":"http://b","weight":5,"backup":false}]}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_when_schema_uses_root_ref() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" },
+                    "enabled": { "type": "boolean", "default": true },
+                    "child": { "$ref": "#" }
+                  }
+                }
+                """;
+
+            String result = validator.validate(
+                schema,
+                """
+                {"name": "parent", "child": {"name": "nested"}}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"parent","enabled":true,"child":{"name":"nested","enabled":true}}"""
+            );
+        }
+
+        @Test
+        void should_resolve_ref_with_escaped_json_pointer_tokens() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "config": { "$ref": "#/$defs/my~1config~0type" }
+                  },
+                  "$defs": {
+                    "my/config~type": {
+                      "type": "object",
+                      "properties": {
+                        "timeout": { "type": "integer", "default": 30 }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            String result = validator.validate(
+                schema,
+                """
+                {"config": {}}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"config":{"timeout":30}}"""
+            );
+        }
+
+        @Test
+        void should_clear_nulls_and_inject_defaults() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+
+            String json = """
+                {
+                    "name": "John",
+                    "age": null,
+                    "citizenship": null
+                }
+                """;
+            String result = validator.validate(schema, json);
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"citizenship":"USA","name":"John"}
+                """
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional properties removal
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class AdditionalProperties {
+
+        @Test
+        void should_remove_additional_properties() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES));
+
+            String json = """
+                { "name": "John", "age": 30, "unknown": 30 }""";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"John","age":30}"""
+            );
+        }
+
+        @Test
+        void should_remove_additional_properties_keeping_pattern_properties() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES_AND_KEEP_PATTERN_PROPERTIES));
+
+            String json = """
+                { "name": "John", "to-keep": "value", "age": 30, "unknown": 30 }""";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"John","to-keep":"value","age":30}"""
+            );
+        }
+
+        @Test
+        void should_remove_additional_properties_in_nested_object() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_NESTED_ADDITIONAL_PROPERTIES));
+
+            String json = """
+                {
+                    "name": "test",
+                    "config": {
+                        "timeout": 5000,
+                        "retries": 3,
+                        "unknownField": "should-be-removed"
+                    }
+                }
+                """;
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"test","config":{"retries":3,"timeout":5000}}
+                """
+            );
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Custom regex validation
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CustomRegex {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "regex", "java-regex" })
+        void should_accept_valid_regex(String regexFormat) throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
+            String json = "{ \"name\": \"^.*[A-Za-z]\\\\d*$\", \"valid\": true }";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo("{\"valid\":true,\"name\":\"^.*[A-Za-z]\\\\d*$\"}");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "regex", "java-regex" })
+        void should_reject_invalid_regex(String regexFormat) throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
+
+            assertThatThrownBy(() ->
+                validator.validate(
+                    schema,
+                    """
+                    { "name": "( INVALID regex", "valid": true }"""
+                )
+            )
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessage("$.name: does not match the %s pattern".formatted(regexFormat));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // OneOf handling
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class OneOf {
+
+        @Test
+        void should_inject_defaults_with_oneOf() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_AND_DEFAULT_VALUE));
+
+            String json = """
+                {
+                    "http": {
+                        "keepAlive": true
+                    }
+                }
+                """;
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"http":{"protocol":"HTTP1","keepAlive":true}}"""
+            );
+        }
+
+        @Test
+        void should_throw_when_oneOf_has_no_common_required_defaults() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_NO_COMMON_DEFAULT));
+
+            assertThatThrownBy(() -> validator.validate(schema, "{}"))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessage("$: must be valid to one and only one schema, but 0 are valid");
+        }
+
+        @Test
+        void should_only_inject_common_required_defaults() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_PARTIAL_REQUIRED));
+
+            String json = """
+                { "onlyInFirst": "provided" }
+                """;
+            String result = validator.validate(schema, json);
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"common":"defaultCommon","onlyInFirst":"provided"}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_when_allOf_wraps_oneOf() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_WRAPPING_ONEOF));
+
+            String json = """
+                { "http": { "version": "HTTP_1_1" } }
+                """;
+            String result = validator.validate(schema, json);
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"http":{"readTimeout":5000,"version":"HTTP_1_1"}}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_when_ref_to_oneOf() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_REF_TO_ONEOF));
+
+            String json = """
+                { "http": { "connectTimeout": 5000 } }
+                """;
+            String result = validator.validate(schema, json);
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"http":{"connectTimeout":5000,"readTimeout":10000,"version":"HTTP_1_1"}}"""
+            );
+        }
+
+        @Test
+        void should_inject_defaults_when_ref_to_oneOf_with_second_subschema_discriminator() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_REF_TO_ONEOF));
+
+            String json = """
+                {
+                    "http": {
+                        "version": "HTTP_2"
                     }
                 }
                 """;
             String result = validator.validate(schema, json);
 
-            // Should keep HTTP type
             assertThatJson(result).isEqualTo(
                 """
-                {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+                {"http":{"readTimeout":10000,"connectTimeout":3000,"version":"HTTP_2"}}
+                """
             );
         }
 
         @Test
-        void should_inject_required_defaults_when_second_subschema_discriminator_provided() throws IOException {
-            String schema = Files.readString(Path.of(SCHEMA_PATH));
+        void should_default_to_first_subschema_when_multiple_oneOf_match() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_MULTIPLE_MATCH));
 
-            // Discriminator for second subschema (GRPC) provided
-            // Should inject GRPC required defaults
+            String json = """
+                { "config": { "timeout": 5000 } }
+                """;
+            String result = validator.validate(schema, json);
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"config":{"timeout":5000,"type":"TYPE_A"}}"""
+            );
+        }
+
+        @Test
+        void should_inject_root_default_when_discriminator_matches_subschema() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
+            String json = """
+                { "partyType": "NATURAL" }""";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"ACME","partyType":"NATURAL"}"""
+            );
+        }
+
+        @Test
+        void should_inject_root_defaults_when_input_empty() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
+            String json = "{\n}";
+            String result = validator.validate(schema, json);
+            assertThatJson(result).isEqualTo(
+                """
+                {"name":"ACME","partyType":"COMPANY"}"""
+            );
+        }
+
+        @Test
+        void should_preserve_pattern_properties_in_oneOf_subschema() throws IOException {
+            String schema = Files.readString(Path.of(SCHEMA_ONEOF_PATTERN_PROPERTIES));
+
             String json = """
                 {
                     "endpoint": {
-                        "type": "GRPC"
+                        "x-custom-header": "value"
                     }
                 }
                 """;
             String result = validator.validate(schema, json);
 
-            // Should keep GRPC type
             assertThatJson(result).isEqualTo(
                 """
-                {"endpoint": {"port":443,"readTimeout":5000,"connectTimeout":3000,"type":"GRPC"}}"""
+                {"endpoint": {"type":"HTTP","x-custom-header":"value"}}"""
             );
+        }
+
+        @Nested
+        class DiscriminatorWithRequiredFields {
+
+            @Test
+            void should_choose_first_subschema_and_inject_required_defaults_when_no_discriminator() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_DISCRIMINATOR_WITH_REQUIRED));
+
+                String json = """
+                    {
+                        "endpoint": {}
+                    }
+                    """;
+                String result = validator.validate(schema, json);
+
+                assertThatJson(result).isEqualTo(
+                    """
+                    {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+                );
+            }
+
+            @Test
+            void should_inject_required_defaults_when_first_subschema_discriminator_provided() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_DISCRIMINATOR_WITH_REQUIRED));
+
+                String json = """
+                    {
+                        "endpoint": {
+                            "type": "HTTP"
+                        }
+                    }
+                    """;
+                String result = validator.validate(schema, json);
+
+                assertThatJson(result).isEqualTo(
+                    """
+                    {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+                );
+            }
+
+            @Test
+            void should_inject_required_defaults_when_second_subschema_discriminator_provided() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_DISCRIMINATOR_WITH_REQUIRED));
+
+                String json = """
+                    {
+                        "endpoint": {
+                            "type": "GRPC"
+                        }
+                    }
+                    """;
+                String result = validator.validate(schema, json);
+
+                assertThatJson(result).isEqualTo(
+                    """
+                    {"endpoint": {"port":443,"readTimeout":5000,"connectTimeout":3000,"type":"GRPC"}}"""
+                );
+            }
+        }
+
+        @Nested
+        class SubschemaFallback {
+
+            @Test
+            void should_pick_first_subschema_when_oneOf_has_no_discriminator() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_NO_DISCRIMINATOR));
+
+                String json = """
+                    {
+                        "endpoint": {}
+                    }
+                    """;
+                String result = validator.validate(schema, json);
+
+                assertThatJson(result).isEqualTo(
+                    """
+                    {"endpoint": {"host":"localhost","port":8080}}"""
+                );
+            }
+
+            @Test
+            void should_throw_when_discriminator_matches_no_branch() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_DISCRIMINATOR_WITH_REQUIRED));
+
+                String json = """
+                    {
+                        "endpoint": {
+                            "type": "UNKNOWN"
+                        }
+                    }
+                    """;
+
+                assertThatThrownBy(() -> validator.validate(schema, json))
+                    .isInstanceOf(InvalidJsonException.class)
+                    .hasMessageContaining("must be valid to one and only one schema");
+            }
+
+            @Test
+            void should_match_freeform_branch_when_const_branch_does_not_match() throws IOException {
+                String schema = Files.readString(Path.of(SCHEMA_ONEOF_MIXED_CONST_FREEFORM));
+
+                String json = """
+                    {
+                        "endpoint": {
+                            "mode": "CUSTOM"
+                        }
+                    }
+                    """;
+                String result = validator.validate(schema, json);
+
+                assertThatJson(result).isEqualTo(
+                    """
+                    {"endpoint": {"mode":"CUSTOM","label":"free"}}"""
+                );
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache behavior
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CacheBehavior {
+
+        @Test
+        void should_cache_schema_once_for_repeated_validation() throws IOException {
+            String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
+            String json = """
+                { "name": "John", "age": 30 }""";
+
+            assertThat(cacheSize()).isZero();
+
+            validator.validate(schema, json);
+            assertThat(cacheSize()).isOne();
+
+            validator.validate(schema, json);
+            assertThat(cacheSize()).isOne();
+        }
+
+        @Test
+        void should_cache_two_entries_for_two_different_schemas() throws IOException {
+            String schema1 = Files.readString(Path.of(SIMPLE_SCHEMA));
+            String schema2 = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+            String json = """
+                { "name": "John", "age": 30 }""";
+
+            validator.validate(schema1, json);
+            assertThat(cacheSize()).isOne();
+
+            validator.validate(schema2, json);
+            assertThat(cacheSize()).isEqualTo(2);
+        }
+
+        @Test
+        void should_not_cache_when_schema_is_empty_or_null() {
+            validator.validate("", "{ } ");
+            assertThat(cacheSize()).isZero();
+
+            validator.validate(null, "{ } ");
+            assertThat(cacheSize()).isZero();
+        }
+
+        @Test
+        void should_cache_once_under_concurrency() throws Exception {
+            String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
+            String json = """
+                { "name": "John", "age": 30 }""";
+
+            int threads = 8;
+            ExecutorService es = Executors.newFixedThreadPool(threads);
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+            java.util.concurrent.atomic.AtomicReference<Throwable> errorReference = new java.util.concurrent.atomic.AtomicReference<>();
+
+            for (int i = 0; i < threads; i++) {
+                es.submit(() -> {
+                    try {
+                        start.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                        validator.validate(schema, json);
+                    } catch (Throwable e) {
+                        errorReference.set(e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
+            es.shutdownNow();
+
+            assertThat(finished).as("Test threads timed out").isTrue();
+            assertThat(errorReference.get()).as("Validation failed in a concurrent thread").isNull();
+            assertThat(cacheSize()).isOne();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression tests
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class Regressions {
+
+        @Test
+        void should_not_stack_overflow_on_circular_ref() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "required": ["foo"],
+                  "properties": {
+                    "foo": { "$ref": "#/$defs/A" }
+                  },
+                  "$defs": {
+                    "A": { "$ref": "#/$defs/B" },
+                    "B": { "$ref": "#/$defs/A" }
+                  }
+                }
+                """;
+
+            assertThatThrownBy(() -> validator.validate(schema, "{}"))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessageContaining("required property 'foo' not found");
+        }
+
+        @Test
+        void should_inject_default_in_array_element_when_required_field_missing() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": ["status"],
+                        "properties": {
+                          "status": { "type": "string", "default": "active" }
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            String result = validator.validate(schema, "{\"items\": [{}]}");
+            assertThatJson(result).isEqualTo(
+                """
+                {"items":[{"status":"active"}]}"""
+            );
+        }
+
+        @Test
+        void should_inject_default_in_nested_array_element() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["priority"],
+                            "properties": {
+                              "priority": { "type": "integer", "default": 0 },
+                              "name": { "type": "string" }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            String result = validator.validate(
+                schema,
+                """
+                {"config": {"rules": [{"name": "rule1"}, {"name": "rule2"}]}}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"config":{"rules":[{"priority":0,"name":"rule1"},{"priority":0,"name":"rule2"}]}}"""
+            );
+        }
+
+        @Test
+        void should_resolve_required_default_when_property_name_contains_slash() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "a/b": {
+                      "type": "object",
+                      "required": ["status"],
+                      "properties": {
+                        "status": { "type": "string", "default": "active" }
+                      }
+                    }
+                  }
+                }
+                """;
+
+            String result = validator.validate(
+                schema,
+                """
+                {"a/b": {}}"""
+            );
+            assertThatJson(result).isEqualTo(
+                """
+                {"a/b":{"status":"active"}}"""
+            );
+        }
+
+        @Test
+        void should_not_swallow_sibling_error_whose_path_shares_a_oneOf_prefix() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "http": {
+                      "type": "object",
+                      "oneOf": [
+                        { "required": ["type"], "properties": { "type": { "const": "HTTP1" } } },
+                        { "required": ["type"], "properties": { "type": { "const": "HTTP2" } } }
+                      ]
+                    },
+                    "httpProxy": {
+                      "type": "object",
+                      "properties": { "mode": { "const": "SYSTEM" } }
+                    }
+                  }
+                }
+                """;
+
+            assertThatThrownBy(() ->
+                validator.validate(
+                    schema,
+                    """
+                    {"http": {}, "httpProxy": {"mode": "WRONG"}}"""
+                )
+            )
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessageContaining("$.httpProxy.mode");
         }
     }
 }

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -410,6 +410,21 @@ class JsonSchemaValidatorImplTest {
         assertThat(cacheSize()).isOne();
     }
 
+    // ---------------- Characterization tests (migration safety net) ----------------
+
+    @Test
+    void should_throw_when_multiple_required_fields_missing_without_defaults() throws IOException {
+        String schema = Files.readString(Path.of("src/test/resources/schema_multiple_required_no_defaults.json"));
+
+        assertThatThrownBy(() -> validator.validate(schema, "{}"))
+            .isInstanceOf(InvalidJsonException.class)
+            .satisfies(ex -> {
+                String message = ex.getMessage();
+                // Current behavior: at least one missing required field is reported
+                assertThat(message).containsAnyOf("firstName", "lastName", "email");
+            });
+    }
+
     // ---------------- OneOf with discriminator and required fields ----------------
 
     @Nested

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -452,8 +452,30 @@ class JsonSchemaValidatorImplTest {
             }
             """;
         String result = validator.validate(schema, json);
-        assertThat(result).contains("\"value\":\"deep-default\"");
-        assertThat(result).contains("\"topField\":\"provided\"");
+        assertThatJson(result).isEqualTo("""
+                {"topField":"provided","level1":{"level2":{"level3":{}}},"level3":{"value":"deep-default"},"level2":{}}
+                """);
+    }
+
+    @Test
+    void should_inject_defaults_when_ref_to_oneof_with_second_subschema_discriminator() throws IOException {
+        String schema = Files.readString(Path.of(SCHEMA_WITH_REF_TO_ONEOF));
+
+        // Discriminator for second subschema (HTTP_2) provided
+        // "readTimeout" and "connectTimeout" are missing but have defaults via $ref
+        String json = """
+            {
+                "http": {
+                    "version": "HTTP_2"
+                }
+            }
+            """;
+        String result = validator.validate(schema, json);
+
+        // Should keep the discriminator value and inject defaults from $ref definitions
+        assertThatJson(result).isEqualTo("""
+                {"http":{"readTimeout":10000,"connectTimeout":3000,"version":"HTTP_2"}}
+                """);
     }
 
     // ---------------- OneOf with discriminator and required fields ----------------

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.json.validation;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,7 +23,9 @@ import com.github.benmanes.caffeine.cache.Cache;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.everit.json.schema.Schema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -79,20 +82,33 @@ class JsonSchemaValidatorImplTest {
     @Test
     void should_return_json_content_when_valid() throws IOException {
         String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30\n" + "}";
+        String json = """
+            { "name": "John",  "age": 30 }""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"name\":\"John\",\"age\":30}");
+        assertThatJson(result).isEqualTo(json);
     }
 
     @Test
     void should_throw_exception_when_invalid() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
 
-        assertThatThrownBy(() -> validator.validate(schema, "{\n" + " \"age\": 30,\n" + "  \"citizenship\": \"FR\"\n" + "}"))
+        assertThatThrownBy(() ->
+            validator.validate(
+                schema,
+                """
+                { "age": 30, "citizenship": "FR" }"""
+            )
+        )
             .isInstanceOf(InvalidJsonException.class)
             .hasMessage("#: required key [name] not found");
 
-        assertThatThrownBy(() -> validator.validate(schema, "{\n" + "  \"name\": \"John\",\n" + " \"age\": true\n" + "}"))
+        assertThatThrownBy(() ->
+            validator.validate(
+                schema,
+                """
+                { "name": "John", "age": true }"""
+            )
+        )
             .isInstanceOf(InvalidJsonException.class)
             .hasMessage("#/age: expected type: Integer, found: Boolean");
     }
@@ -101,19 +117,29 @@ class JsonSchemaValidatorImplTest {
     void should_return_updated_json_required_default_value_missing() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
 
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30\n" + "}";
+        String json = """
+            { "name": "John",  "age": 30 }""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"citizenship\":\"USA\",\"name\":\"John\",\"age\":30}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"citizenship":"USA","name":"John","age":30}"""
+        );
 
         schema = Files.readString(Path.of(SCHEMA_WITH_NESTED_DEFAULT_VALUE));
         result = validator.validate(schema, "{\"additional-property\": true}");
-        assertThat(result).isEqualTo(
-            "{\"additional-property\":true,\"address\":{\"city\":\"Lille\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}"
+        assertThatJson(result).isEqualTo(
+            """
+            {"additional-property":true,"address":{"city":"Lille"},"citizenship":"France","name":"John Doe"}"""
         );
 
-        result = validator.validate(schema, "{\"additional-property\": true, \"address\": {}}");
-        assertThat(result).isEqualTo(
-            "{\"additional-property\":true,\"address\":{\"city\":\"Paris\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}"
+        result = validator.validate(
+            schema,
+            """
+            {"additional-property": true, "address": {}}"""
+        );
+        assertThatJson(result).isEqualTo(
+            """
+            {"additional-property":true,"address":{"city":"Paris"},"citizenship":"France","name":"John Doe"}"""
         );
     }
 
@@ -121,9 +147,13 @@ class JsonSchemaValidatorImplTest {
     void should_return_updated_json_required_default_value_with_allOf() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_ALLOF_AND_DEFAULT_VALUE));
 
-        String json = "{\"citizenship\": \"FR\"}";
+        String json = """
+            {"citizenship": "FR"}""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"citizenship\":\"FR\",\"status\":\"A\"}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"citizenship":"FR","status":"A"}"""
+        );
     }
 
     @Test
@@ -139,7 +169,10 @@ class JsonSchemaValidatorImplTest {
             }
             """;
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"http\":{\"protocol\":\"HTTP1\",\"keepAlive\":true}}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"http":{"protocol":"HTTP1","keepAlive":true}}"""
+        );
     }
 
     @Test
@@ -158,16 +191,15 @@ class JsonSchemaValidatorImplTest {
         // "onlyInFirst" is required only in first subschema -> should NOT be injected
         // "onlyInSecond" is required only in second subschema -> should NOT be injected
         String json = """
-            {
-                "onlyInFirst": "provided"
-            }
+            { "onlyInFirst": "provided" }
             """;
         String result = validator.validate(schema, json);
 
         // Only "common" should be added, not "onlyInSecond"
-        assertThat(result).contains("\"common\":\"defaultCommon\"");
-        assertThat(result).contains("\"onlyInFirst\":\"provided\"");
-        assertThat(result).doesNotContain("onlyInSecond");
+        assertThatJson(result).isEqualTo(
+            """
+            {"common":"defaultCommon","onlyInFirst":"provided"}"""
+        );
     }
 
     @Test
@@ -177,17 +209,15 @@ class JsonSchemaValidatorImplTest {
         // "readTimeout" is required in both oneOf subschemas and has a default value
         // The oneOf is wrapped inside an allOf, so we need to traverse the causingExceptions
         String json = """
-            {
-                "http": {
-                    "version": "HTTP_1_1"
-                }
-            }
+            { "http": { "version": "HTTP_1_1" } }
             """;
         String result = validator.validate(schema, json);
 
         // "readTimeout" should be injected with its default value 10000
-        assertThat(result).contains("\"readTimeout\":10000");
-        assertThat(result).contains("\"version\":\"HTTP_1_1\"");
+        assertThatJson(result).isEqualTo(
+            """
+            {"http":{"connectTimeout":5000,"readTimeout":10000,"version":"HTTP_1_1"}}"""
+        );
     }
 
     @Test
@@ -198,16 +228,15 @@ class JsonSchemaValidatorImplTest {
         // The schema uses $ref to a definition containing oneOf with "type": "object"
         // This creates an internal allOf (type + oneOf) that wraps the oneOf error
         String json = """
-            {
-                "http": {
-                    "connectTimeout": 5000
-                }
-            }
+            { "http": { "connectTimeout": 5000 } }
             """;
         String result = validator.validate(schema, json);
 
         // "readTimeout" should be injected with its default value 10000
-        assertThat(result).contains("\"readTimeout\":10000");
+        assertThatJson(result).isEqualTo(
+            """
+            {"http":{"connectTimeout":5000,"readTimeout":10000,"version":"HTTP_1_1"}}"""
+        );
     }
 
     @Test
@@ -217,25 +246,27 @@ class JsonSchemaValidatorImplTest {
         // When no "type" is provided, both subschemas would match (they only differ by const value)
         // The validator should default to the first subschema and inject its const value
         String json = """
-            {
-                "config": {
-                    "timeout": 5000
-                }
-            }
+            { "config": { "timeout": 5000 } }
             """;
         String result = validator.validate(schema, json);
 
         // Should inject "type": "TYPE_A" from the first subschema
-        assertThat(result).contains("\"type\":\"TYPE_A\"");
-        assertThat(result).contains("\"timeout\":5000");
+        assertThatJson(result).isEqualTo(
+            """
+            {"config":{"timeout":5000,"type":"TYPE_A"}}"""
+        );
     }
 
     @Test
     void should_inject_root_default_when_discriminator_matches_subschema_oneof() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
-        String json = "{\n" + "  \"partyType\": \"NATURAL\",\n" + "}";
+        String json = """
+            { "partyType": "NATURAL" }""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"name\":\"ACME\",\"partyType\":\"NATURAL\"}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"name":"ACME","partyType":"NATURAL"}"""
+        );
     }
 
     @Test
@@ -243,25 +274,36 @@ class JsonSchemaValidatorImplTest {
         String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_REQUIRED_WITH_ROOT_DEFAULTS));
         String json = "{\n}";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"name\":\"ACME\",\"partyType\":\"COMPANY\"}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"name":"ACME","partyType":"COMPANY"}"""
+        );
     }
 
     @Test
     void should_return_updated_json_with_additional_properties_removed() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES));
 
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30,\n" + "  \"unknown\": 30\n" + "}";
+        String json = """
+            { "name": "John", "age": 30, "unknown": 30 }""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"name\":\"John\",\"age\":30}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"name":"John","age":30}"""
+        );
     }
 
     @Test
     void should_return_updated_json_with_additional_properties_removed_keeping_pattern_properties() throws IOException {
         String schema = Files.readString(Path.of(SCHEMA_WITH_NOT_ALLOWED_ADDITIONAL_PROPERTIES_AND_KEEP_PATTERN_PROPERTIES));
 
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"to-keep\": \"value\",\n" + "  \"age\": 30,\n" + "  \"unknown\": 30\n" + "}";
+        String json = """
+            { "name": "John", "to-keep": "value", "age": 30, "unknown": 30 }""";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"name\":\"John\",\"to-keep\":\"value\",\"age\":30}");
+        assertThatJson(result).isEqualTo(
+            """
+            {"name":"John","to-keep":"value","age":30}"""
+        );
     }
 
     @ParameterizedTest
@@ -270,7 +312,7 @@ class JsonSchemaValidatorImplTest {
         String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
         String json = "{ \"name\": \"^.*[A-Za-z]\\\\d*$\", \"valid\": true }";
         String result = validator.validate(schema, json);
-        assertThat(result).isEqualTo("{\"valid\":true,\"name\":\"^.*[A-Za-z]\\\\d*$\"}");
+        assertThatJson(result).isEqualTo("{\"valid\":true,\"name\":\"^.*[A-Za-z]\\\\d*$\"}");
     }
 
     @ParameterizedTest
@@ -278,7 +320,13 @@ class JsonSchemaValidatorImplTest {
     public void should_reject_invalid_json_due_to_invalid_regex(String regexFormat) throws Exception {
         String schema = Files.readString(Path.of(SCHEMA_WITH_CUSTOM_REGEX)).replace("regex", regexFormat);
 
-        assertThatThrownBy(() -> validator.validate(schema, "{ \"name\": \"( INVALID regex\", \"valid\": true }"))
+        assertThatThrownBy(() ->
+            validator.validate(
+                schema,
+                """
+                { "name": "( INVALID regex", "valid": true }"""
+            )
+        )
             .isInstanceOf(InvalidJsonException.class)
             .hasMessage("#/name: [( INVALID regex] is not a valid regular expression");
     }
@@ -288,27 +336,29 @@ class JsonSchemaValidatorImplTest {
     @Test
     void should_cache_schema_once_for_repeated_validation() throws Exception {
         String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30\n" + "}";
+        String json = """
+            { "name": "John", "age": 30 }""";
 
         assertThat(cacheSize()).isZero();
 
         // First validation builds and caches the schema
         validator.validate(schema, json);
-        assertThat(cacheSize()).isEqualTo(1);
+        assertThat(cacheSize()).isOne();
 
         // Second validation with same schema should reuse cache (still 1)
         validator.validate(schema, json);
-        assertThat(cacheSize()).isEqualTo(1);
+        assertThat(cacheSize()).isOne();
     }
 
     @Test
     void should_cache_two_entries_for_two_different_schemas() throws Exception {
         String schema1 = Files.readString(Path.of(SIMPLE_SCHEMA));
         String schema2 = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30\n" + "}";
+        String json = """
+            { "name": "John", "age": 30 }""";
 
         validator.validate(schema1, json);
-        assertThat(cacheSize()).isEqualTo(1);
+        assertThat(cacheSize()).isOne();
 
         validator.validate(schema2, json);
         assertThat(cacheSize()).isEqualTo(2);
@@ -328,7 +378,8 @@ class JsonSchemaValidatorImplTest {
     @Test
     void should_cache_once_under_concurrency() throws Exception {
         String schema = Files.readString(Path.of(SIMPLE_SCHEMA));
-        String json = "{\n" + "  \"name\": \"John\",\n" + "  \"age\": 30\n" + "}";
+        String json = """
+            { "name": "John", "age": 30 }""";
 
         int threads = 8;
         ExecutorService es = Executors.newFixedThreadPool(threads);
@@ -356,7 +407,7 @@ class JsonSchemaValidatorImplTest {
 
         assertThat(finished).as("Test threads timed out").isTrue();
         assertThat(errorReference.get()).as("Validation failed in a concurrent thread").isNull();
-        assertThat(cacheSize()).isEqualTo(1);
+        assertThat(cacheSize()).isOne();
     }
 
     // ---------------- OneOf with discriminator and required fields ----------------
@@ -393,14 +444,10 @@ class JsonSchemaValidatorImplTest {
             String result = validator.validate(schema, json);
 
             // Should have HTTP type (const from first subschema)
-            assertThat(result).contains("\"type\":\"HTTP\"");
-            // Should have HTTP defaults
-            assertThat(result).contains("\"connectTimeout\":5000");
-            assertThat(result).contains("\"readTimeout\":10000");
-            // Should have HTTP-specific field
-            assertThat(result).contains("\"keepAliveTimeout\":30000");
-            // Should NOT have GRPC-specific field
-            assertThat(result).doesNotContain("\"port\"");
+            assertThatJson(result).isEqualTo(
+                """
+                {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+            );
         }
 
         @Test
@@ -419,14 +466,10 @@ class JsonSchemaValidatorImplTest {
             String result = validator.validate(schema, json);
 
             // Should keep HTTP type
-            assertThat(result).contains("\"type\":\"HTTP\"");
-            // Should have HTTP defaults
-            assertThat(result).contains("\"connectTimeout\":5000");
-            assertThat(result).contains("\"readTimeout\":10000");
-            // Should have HTTP-specific field
-            assertThat(result).contains("\"keepAliveTimeout\":30000");
-            // Should NOT have GRPC-specific field
-            assertThat(result).doesNotContain("\"port\"");
+            assertThatJson(result).isEqualTo(
+                """
+                {"endpoint": {"keepAliveTimeout":30000,"readTimeout":10000,"connectTimeout":5000,"type":"HTTP"}}"""
+            );
         }
 
         @Test
@@ -445,14 +488,10 @@ class JsonSchemaValidatorImplTest {
             String result = validator.validate(schema, json);
 
             // Should keep GRPC type
-            assertThat(result).contains("\"type\":\"GRPC\"");
-            // Should have GRPC defaults
-            assertThat(result).contains("\"connectTimeout\":3000");
-            assertThat(result).contains("\"readTimeout\":5000");
-            // Should have GRPC-specific field with its default
-            assertThat(result).contains("\"port\":443");
-            // Should NOT have HTTP-specific field
-            assertThat(result).doesNotContain("\"keepAliveTimeout\"");
+            assertThatJson(result).isEqualTo(
+                """
+                {"endpoint": {"port":443,"readTimeout":5000,"connectTimeout":3000,"type":"GRPC"}}"""
+            );
         }
     }
 }

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -783,31 +783,33 @@ class JsonSchemaValidatorImplTest {
                 { "name": "John", "age": 30 }""";
 
             int threads = 8;
-            ExecutorService es = Executors.newFixedThreadPool(threads);
             CountDownLatch start = new CountDownLatch(1);
             CountDownLatch done = new CountDownLatch(threads);
             java.util.concurrent.atomic.AtomicReference<Throwable> errorReference = new java.util.concurrent.atomic.AtomicReference<>();
 
-            for (int i = 0; i < threads; i++) {
-                es.submit(() -> {
-                    try {
-                        start.await(5, java.util.concurrent.TimeUnit.SECONDS);
-                        validator.validate(schema, json);
-                    } catch (Throwable e) {
-                        errorReference.set(e);
-                    } finally {
-                        done.countDown();
-                    }
-                });
+            try (ExecutorService es = Executors.newFixedThreadPool(threads)) {
+                for (int i = 0; i < threads; i++) {
+                    es.submit(() -> {
+                        try {
+                            if (!start.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                                throw new IllegalStateException("Timed out waiting for start latch");
+                            }
+                            validator.validate(schema, json);
+                        } catch (Throwable e) {
+                            errorReference.set(e);
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+                }
+
+                start.countDown();
+                boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
+
+                assertThat(finished).as("Test threads timed out").isTrue();
+                assertThat(errorReference.get()).as("Validation failed in a concurrent thread").isNull();
+                assertThat(cacheSize()).isOne();
             }
-
-            start.countDown();
-            boolean finished = done.await(10, java.util.concurrent.TimeUnit.SECONDS);
-            es.shutdownNow();
-
-            assertThat(finished).as("Test threads timed out").isTrue();
-            assertThat(errorReference.get()).as("Validation failed in a concurrent thread").isNull();
-            assertThat(cacheSize()).isOne();
         }
     }
 

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -107,12 +107,14 @@ class JsonSchemaValidatorImplTest {
 
         schema = Files.readString(Path.of(SCHEMA_WITH_NESTED_DEFAULT_VALUE));
         result = validator.validate(schema, "{\"additional-property\": true}");
-        assertThat(result)
-            .isEqualTo("{\"additional-property\":true,\"address\":{\"city\":\"Lille\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}");
+        assertThat(result).isEqualTo(
+            "{\"additional-property\":true,\"address\":{\"city\":\"Lille\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}"
+        );
 
         result = validator.validate(schema, "{\"additional-property\": true, \"address\": {}}");
-        assertThat(result)
-            .isEqualTo("{\"additional-property\":true,\"address\":{\"city\":\"Paris\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}");
+        assertThat(result).isEqualTo(
+            "{\"additional-property\":true,\"address\":{\"city\":\"Paris\"},\"citizenship\":\"France\",\"name\":\"John Doe\"}"
+        );
     }
 
     @Test
@@ -129,8 +131,7 @@ class JsonSchemaValidatorImplTest {
         String schema = Files.readString(Path.of(SCHEMA_WITH_ONEOF_AND_DEFAULT_VALUE));
 
         // Missing "protocol" in nested "http" object - should inject default "HTTP1"
-        String json =
-            """
+        String json = """
             {
                 "http": {
                     "keepAlive": true
@@ -175,8 +176,7 @@ class JsonSchemaValidatorImplTest {
 
         // "readTimeout" is required in both oneOf subschemas and has a default value
         // The oneOf is wrapped inside an allOf, so we need to traverse the causingExceptions
-        String json =
-            """
+        String json = """
             {
                 "http": {
                     "version": "HTTP_1_1"
@@ -197,8 +197,7 @@ class JsonSchemaValidatorImplTest {
         // "readTimeout" is missing but has a default value in the schema
         // The schema uses $ref to a definition containing oneOf with "type": "object"
         // This creates an internal allOf (type + oneOf) that wraps the oneOf error
-        String json =
-            """
+        String json = """
             {
                 "http": {
                     "connectTimeout": 5000
@@ -217,8 +216,7 @@ class JsonSchemaValidatorImplTest {
 
         // When no "type" is provided, both subschemas would match (they only differ by const value)
         // The validator should default to the first subschema and inject its const value
-        String json =
-            """
+        String json = """
             {
                 "config": {
                     "timeout": 5000
@@ -343,7 +341,8 @@ class JsonSchemaValidatorImplTest {
                 try {
                     start.await(5, java.util.concurrent.TimeUnit.SECONDS);
                     validator.validate(schema, json);
-                } catch (Throwable e) { // Catch Throwable to handle Errors too, not just Exceptions
+                } catch (Throwable e) {
+                    // Catch Throwable to handle Errors too, not just Exceptions
                     errorReference.set(e);
                 } finally {
                     done.countDown();
@@ -410,8 +409,7 @@ class JsonSchemaValidatorImplTest {
 
             // Discriminator for first subschema (HTTP) provided
             // Should inject HTTP required defaults
-            String json =
-                """
+            String json = """
                 {
                     "endpoint": {
                         "type": "HTTP"
@@ -437,8 +435,7 @@ class JsonSchemaValidatorImplTest {
 
             // Discriminator for second subschema (GRPC) provided
             // Should inject GRPC required defaults
-            String json =
-                """
+            String json = """
                 {
                     "endpoint": {
                         "type": "GRPC"

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -478,6 +478,29 @@ class JsonSchemaValidatorImplTest {
                 """);
     }
 
+    @Test
+    void should_not_remove_additional_properties_in_nested_object() throws IOException {
+        // Current behavior: additionalProperties removal only works at root level.
+        // Nested additional properties are NOT removed — they remain in the output.
+        String schema = Files.readString(Path.of("src/test/resources/schema_nested_additional_properties.json"));
+
+        String json = """
+            {
+                "name": "test",
+                "config": {
+                    "timeout": 5000,
+                    "retries": 3,
+                    "unknownField": "should-be-removed"
+                }
+            }
+            """;
+        String result = validator.validate(schema, json);
+        // Note: unknownField is NOT removed in nested objects (current limitation)
+        assertThatJson(result).isEqualTo("""
+                {"name":"test","config":{"retries":3,"unknownField":"should-be-removed","timeout":5000}}
+                """);
+    }
+
     // ---------------- OneOf with discriminator and required fields ----------------
 
     @Nested

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -501,6 +501,27 @@ class JsonSchemaValidatorImplTest {
                 """);
     }
 
+    @Test
+    void should_clear_nulls_and_inject_defaults() throws IOException {
+        String schema = Files.readString(Path.of(SCHEMA_WITH_DEFAULT_VALUE));
+
+        // "citizenship" is null (will be cleared) and has a default "USA"
+        // "name" is provided, "age" is null (will be cleared, not required)
+        String json = """
+            {
+                "name": "John",
+                "age": null,
+                "citizenship": null
+            }
+            """;
+        String result = validator.validate(schema, json);
+
+        // null values should be cleared first, then defaults injected
+        assertThatJson(result).isEqualTo("""
+                {"citizenship":"USA","name":"John"}
+                """);
+    }
+
     // ---------------- OneOf with discriminator and required fields ----------------
 
     @Nested

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -425,6 +425,37 @@ class JsonSchemaValidatorImplTest {
             });
     }
 
+    @Test
+    void should_inject_defaults_in_deeply_nested_schema() throws IOException {
+        String schema = Files.readString(Path.of("src/test/resources/schema_deeply_nested_defaults.json"));
+
+        // Empty object — all defaults at 3+ levels should be injected
+        String result = validator.validate(schema, "{}");
+        assertThatJson(result).isEqualTo("""
+                {"topField":"top-default","level1":{"level2":{"level3":{"value":"deep-default"}}}}
+                """);
+    }
+
+    @Test
+    void should_inject_defaults_at_deepest_level_when_parents_exist() throws IOException {
+        String schema = Files.readString(Path.of("src/test/resources/schema_deeply_nested_defaults.json"));
+
+        // Parents exist but deepest value is missing
+        String json = """
+            {
+                "level1": {
+                    "level2": {
+                        "level3": {}
+                    }
+                },
+                "topField": "provided"
+            }
+            """;
+        String result = validator.validate(schema, json);
+        assertThat(result).contains("\"value\":\"deep-default\"");
+        assertThat(result).contains("\"topField\":\"provided\"");
+    }
+
     // ---------------- OneOf with discriminator and required fields ----------------
 
     @Nested

--- a/src/test/resources/schema_allof_wrapping_oneof.json
+++ b/src/test/resources/schema_allof_wrapping_oneof.json
@@ -20,7 +20,7 @@
                             "properties": {
                                 "readTimeout": {
                                     "type": "integer",
-                                    "default": 10000
+                                    "default": 5000
                                 },
                                 "version": {
                                     "type": "string",

--- a/src/test/resources/schema_deeply_nested_defaults.json
+++ b/src/test/resources/schema_deeply_nested_defaults.json
@@ -1,0 +1,47 @@
+{
+    "type": "object",
+    "properties": {
+        "level1": {
+            "type": "object",
+            "properties": {
+                "level2": {
+                    "type": "object",
+                    "properties": {
+                        "level3": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "type": "string",
+                                    "default": "deep-default"
+                                }
+                            },
+                            "required": ["value"],
+                            "default": {
+                                "value": "deep-default"
+                            }
+                        }
+                    },
+                    "required": ["level3"],
+                    "default": {
+                        "level3": {
+                            "value": "deep-default"
+                        }
+                    }
+                }
+            },
+            "required": ["level2"],
+            "default": {
+                "level2": {
+                    "level3": {
+                        "value": "deep-default"
+                    }
+                }
+            }
+        },
+        "topField": {
+            "type": "string",
+            "default": "top-default"
+        }
+    },
+    "required": ["level1", "topField"]
+}

--- a/src/test/resources/schema_multiple_required_no_defaults.json
+++ b/src/test/resources/schema_multiple_required_no_defaults.json
@@ -1,0 +1,16 @@
+{
+    "type": "object",
+    "properties": {
+        "firstName": {
+            "type": "string"
+        },
+        "lastName": {
+            "type": "string"
+        },
+        "email": {
+            "type": "string"
+        }
+    },
+    "required": ["firstName", "lastName", "email"],
+    "additionalProperties": false
+}

--- a/src/test/resources/schema_nested_additional_properties.json
+++ b/src/test/resources/schema_nested_additional_properties.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "timeout": {
+                    "type": "integer"
+                },
+                "retries": {
+                    "type": "integer"
+                }
+            },
+            "required": ["timeout"],
+            "additionalProperties": false
+        }
+    },
+    "required": ["name"]
+}

--- a/src/test/resources/schema_oneof_mixed_const_freeform.json
+++ b/src/test/resources/schema_oneof_mixed_const_freeform.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "endpoint": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "Fixed",
+                    "properties": {
+                        "mode": { "const": "FIXED" },
+                        "value": { "type": "integer", "default": 1 }
+                    },
+                    "required": ["mode", "value"],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "Free",
+                    "properties": {
+                        "mode": { "type": "string" },
+                        "label": { "type": "string", "default": "free" }
+                    },
+                    "required": ["mode", "label"],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    }
+}

--- a/src/test/resources/schema_oneof_no_discriminator.json
+++ b/src/test/resources/schema_oneof_no_discriminator.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "endpoint": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "title": "TCP Endpoint",
+                    "properties": {
+                        "host": { "type": "string", "default": "localhost" },
+                        "port": { "type": "integer", "default": 8080 }
+                    },
+                    "required": ["host", "port"],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "Unix Socket Endpoint",
+                    "properties": {
+                        "socketPath": { "type": "string", "default": "/var/run/app.sock" }
+                    },
+                    "required": ["socketPath"],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    }
+}

--- a/src/test/resources/schema_oneof_pattern_properties.json
+++ b/src/test/resources/schema_oneof_pattern_properties.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "endpoint": {
+            "type": "object",
+            "properties": {
+                "type": { "type": "string", "default": "HTTP" }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": { "const": "HTTP" },
+                        "timeout": { "type": "integer", "default": 5000 }
+                    },
+                    "patternProperties": {
+                        "^x-": { "type": "string" }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                },
+                {
+                    "properties": {
+                        "type": { "const": "GRPC" },
+                        "port": { "type": "integer", "default": 443 }
+                    },
+                    "required": ["type"],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    }
+}

--- a/src/test/resources/schema_root_ref.json
+++ b/src/test/resources/schema_root_ref.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/config",
+    "definitions": {
+        "config": {
+            "type": "object",
+            "properties": {
+                "timeout": { "type": "integer", "default": 5000 }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Replace the unmaintained library everit-json-schema with networknt/json-schema-validator, which natively uses Jackson, aligning with Gravitee's standardization on Jackson for JSON processing.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

Update gravitee-parent. The library is now compiled using Java21
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-move-to-another-validation-lib-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/3.0.0-move-to-another-validation-lib-SNAPSHOT/gravitee-json-validation-3.0.0-move-to-another-validation-lib-SNAPSHOT.zip)
  <!-- Version placeholder end -->
