### PR TITLE
fix: skip non-required defaults when schema declares required array

### DIFF
--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -33,6 +33,7 @@ import com.networknt.schema.SchemaRegistryConfig;
 import com.networknt.schema.dialect.Dialect;
 import com.networknt.schema.dialect.Draft7;
 import com.networknt.schema.format.Format;
+import com.networknt.schema.keyword.AnnotationKeyword;
 import com.networknt.schema.path.PathType;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -57,10 +58,15 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
      * Default networknt regex format validates against ECMA-262 syntax; existing schemas use Java Pattern syntax.
      * Override registers JavaRegexFormat for both regex and java-regex names so schema patterns compile via
      * java.util.regex.Pattern instead of being rejected.
+     *
+     * Legacy Gravitee schemas carry the Draft 4 "id" keyword (renamed to "$id" in Draft 6+). Draft 7 has no
+     * validator registered for bare "id", so SchemaRegistry throws "No suitable validator for id" on those
+     * documents. Registering it as an AnnotationKeyword makes it a no-op so the schemas compile.
      */
     private static final Dialect DRAFT7_WITH_REGEX = Dialect.builder(Draft7.getInstance())
         .format(new JavaRegexFormat("java-regex"))
         .format(new JavaRegexFormat("regex"))
+        .keyword(new AnnotationKeyword("id"))
         .build();
 
     /**

--- a/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
+++ b/src/main/java/io/gravitee/json/validation/JsonSchemaValidatorImpl.java
@@ -543,13 +543,24 @@ public class JsonSchemaValidatorImpl implements JsonSchemaValidator {
         JsonNode properties = resolved.get("properties");
         if (properties == null) return;
 
+        // When the schema declares "required", restrict auto-injection to those properties. Non-required
+        // fields are treated as opt-in: the caller's omission is intentional, so we don't populate them
+        // even when they carry a default. Without a "required" array we fall back to injecting every
+        // default — legacy behavior relied on by schemas that lean on defaults instead of requirements.
+        Set<String> requiredFields = null;
+        JsonNode requiredArray = resolved.get("required");
+        if (requiredArray != null && requiredArray.isArray()) {
+            requiredFields = new HashSet<>();
+            for (JsonNode r : requiredArray) requiredFields.add(r.asText());
+        }
+
         for (Map.Entry<String, JsonNode> entry : properties.properties()) {
             String propName = entry.getKey();
             JsonNode propSchema = resolveRef(schemaRoot, entry.getValue());
             if (propSchema == null) continue;
 
             if (!objectNode.has(propName)) {
-                if (propSchema.has("default")) {
+                if (propSchema.has("default") && (requiredFields == null || requiredFields.contains(propName))) {
                     objectNode.set(propName, propSchema.get("default").deepCopy());
                 }
             } else {

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -367,6 +367,51 @@ class JsonSchemaValidatorImplTest {
                 """
             );
         }
+
+        @Test
+        void should_only_inject_required_defaults_when_required_array_is_present() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "requiredWithDefault": { "type": "string", "default": "req-default" },
+                    "optionalWithDefault": { "type": "string", "default": "opt-default" },
+                    "anotherOptional":     { "type": "boolean", "default": true }
+                  },
+                  "required": ["requiredWithDefault"]
+                }
+                """;
+
+            String result = validator.validate(schema, "{}");
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"requiredWithDefault":"req-default"}"""
+            );
+        }
+
+        @Test
+        void should_inject_all_defaults_when_no_required_array() {
+            String schema = """
+                {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "first":  { "type": "string", "default": "first-default" },
+                    "second": { "type": "boolean", "default": false },
+                    "third":  { "type": "integer", "default": 42 }
+                  }
+                }
+                """;
+
+            String result = validator.validate(schema, "{}");
+
+            assertThatJson(result).isEqualTo(
+                """
+                {"first":"first-default","second":false,"third":42}"""
+            );
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
+++ b/src/test/java/io/gravitee/json/validation/JsonSchemaValidatorImplTest.java
@@ -1015,4 +1015,30 @@ class JsonSchemaValidatorImplTest {
                 .hasMessageContaining("$.httpProxy.mode");
         }
     }
+
+    @Nested
+    class RealUseCases {
+
+        @Test
+        public void should_accept_valid_json_configuration_with_dependencies() throws IOException {
+            String schema = Files.readString(Path.of("src/test/resources/schema_http_connector.json"));
+            String configuration = """
+                {
+                  "ssl": {
+                    "trustStore": {
+                      "type": "PEM",
+                      "path": "..."
+                     }
+                  },
+                  "http": {
+                    "readTimeout": 7777
+                  }
+                }""";
+            String validate = validator.validate(schema, configuration);
+            assertThatJson(validate).isEqualTo(
+                """
+                {"http":{"keepAliveTimeout":30000,"readTimeout":7777,"idleTimeout":60000,"connectTimeout":5000,"maxConcurrentConnections":100},"ssl":{"trustStore":{"path":"...","type":"PEM"},"hostnameVerifier":false,"trustAll":false}}"""
+            );
+        }
+    }
 }

--- a/src/test/resources/schema_http_connector.json
+++ b/src/test/resources/schema_http_connector.json
@@ -1,0 +1,581 @@
+{
+    "type": "object",
+    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpConnectorConfiguration",
+    "properties": {
+        "http": {
+            "type": "object",
+            "title": "HTTP Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpOptions",
+            "properties": {
+                "clearTextUpgrade": {
+                    "title": "Allow h2c Clear Text Upgrade",
+                    "description": "If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge) ",
+                    "type": "boolean",
+                    "default": true,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "http.version": "HTTP_1_1"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "version": {
+                    "title": "HTTP Protocol version",
+                    "description": "The version of the HTTP protocol to use",
+                    "type": "string",
+                    "default": "HTTP_1_1",
+                    "enum": ["HTTP_1_1", "HTTP_2"],
+                    "x-schema-form": {
+                        "type": "select",
+                        "titleMap": {
+                            "HTTP_1_1": "HTTP 1.1",
+                            "HTTP_2": "HTTP 2"
+                        }
+                    }
+                },
+                "keepAlive": {
+                    "title": "Enable keep-alive",
+                    "description": "Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "connectTimeout": {
+                    "type": "integer",
+                    "title": "Connect timeout (ms)",
+                    "description": "Maximum time to connect to the remote host.",
+                    "default": 5000
+                },
+                "pipelining": {
+                    "title": "Enable HTTP pipelining",
+                    "description": "When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.\n",
+                    "type": "boolean",
+                    "default": false
+                },
+                "readTimeout": {
+                    "type": "integer",
+                    "title": "Read timeout (ms)",
+                    "description": "Maximum time to complete the request (including response).",
+                    "default": 10000
+                },
+                "useCompression": {
+                    "title": "Enable compression (gzip, deflate)",
+                    "description": "The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.",
+                    "type": "boolean",
+                    "default": true
+                },
+                "idleTimeout": {
+                    "type": "integer",
+                    "title": "Idle timeout (ms)",
+                    "description": "Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.",
+                    "default": 60000
+                },
+                "propagateClientAcceptEncoding": {
+                    "title": "Propagate client Accept-Encoding header (no decompression if any)",
+                    "description": "The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.",
+                    "type": "boolean",
+                    "default": false,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "http.useCompression": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "keepAliveTimeout": {
+                    "type": "integer",
+                    "title": "Keep-alive timeout (ms)",
+                    "description": "Maximum time a connection will remain unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.",
+                    "default": 30000
+                },
+                "followRedirects": {
+                    "title": "Follow HTTP redirects",
+                    "description": "When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header",
+                    "type": "boolean",
+                    "default": false
+                },
+                "maxConcurrentConnections": {
+                    "type": "integer",
+                    "title": "Max Concurrent Connections",
+                    "description": "Maximum pool size for connections.",
+                    "default": 100
+                }
+            },
+            "required": ["connectTimeout", "readTimeout", "idleTimeout", "keepAliveTimeout", "maxConcurrentConnections"]
+        },
+        "headers": {
+            "type": "array",
+            "title": "HTTP Headers",
+            "description": "Default HTTP headers added or overridden by the API gateway to upstream",
+            "items": {
+                "type": "object",
+                "title": "Header",
+                "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpHeader",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "value": {
+                        "type": "string",
+                        "title": "Value"
+                    }
+                },
+                "required": ["name", "value"]
+            }
+        },
+        "proxy": {
+            "type": "object",
+            "title": "Proxy Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:HttpProxyOptions",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Use proxy",
+                    "description": "Use proxy for client connections",
+                    "default": false
+                },
+                "type": {
+                    "type": "string",
+                    "title": "Proxy Type",
+                    "description": "The type of the proxy",
+                    "default": "HTTP",
+                    "enum": ["HTTP", "SOCKS4", "SOCKS5"],
+                    "x-schema-form": {
+                        "type": "select",
+                        "titleMap": {
+                            "HTTP": "HTTP CONNECT proxy",
+                            "SOCKS4": "SOCKS4/4a tcp proxy",
+                            "SOCKS5": "SOCKS5 tcp proxy"
+                        },
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "useSystemProxy": {
+                    "type": "boolean",
+                    "title": "Use system proxy",
+                    "description": "Use proxy configured at system level",
+                    "default": false,
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ]
+                    }
+                },
+                "host": {
+                    "type": "string",
+                    "title": "Proxy host",
+                    "description": "Proxy host to connect to",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "port": {
+                    "type": "integer",
+                    "title": "Proxy port",
+                    "description": "Proxy port to connect to",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "username": {
+                    "type": "string",
+                    "title": "Proxy username",
+                    "description": "Optional proxy username",
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "password": {
+                    "type": "string",
+                    "title": "Proxy password",
+                    "description": "Optional proxy password",
+                    "x-schema-form": {
+                        "type": "password",
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "proxy.enabled": false
+                                }
+                            }
+                        ],
+                        "disabled": [
+                            {
+                                "$eq": {
+                                    "proxy.useSystemProxy": true
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": { "enabled": { "const": false } }
+                },
+                {
+                    "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
+                },
+                {
+                    "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },
+                    "required": ["host", "port"]
+                }
+            ]
+        },
+        "ssl": {
+            "type": "object",
+            "title": "SSL Options",
+            "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslOptions",
+            "properties": {
+                "hostnameVerifier": {
+                    "title": "Verify Host",
+                    "description": "Use to enable host name verification",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trustAll": {
+                    "title": "Trust all",
+                    "description": "Use this with caution (if over Internet). The gateway must trust any origin certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "trustStore": {
+                    "type": "object",
+                    "title": "Trust store",
+                    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslTrustStoreOptions",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The type of the trust store",
+                            "default": "",
+                            "enum": ["", "JKS", "PKCS12", "PEM"],
+                            "x-schema-form": {
+                                "type": "select",
+                                "titleMap": {
+                                    "": "None",
+                                    "JKS": "Java Trust Store (.jks)",
+                                    "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
+                                    "PEM": "PEM (.pem)"
+                                }
+                            }
+                        },
+                        "password": {
+                            "type": "string",
+                            "title": "Password",
+                            "description": "Trust store password",
+                            "x-schema-form": {
+                                "type": "password",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "Path to trust store",
+                            "description": "Path to the trust store file",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ""
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "content": {
+                            "type": "string",
+                            "title": "Content",
+                            "description": "Binary content as Base64",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.trustStore.type": ""
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "properties": { "type": { "const": "" } }
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["content"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["path"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["content", "password"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["path", "password"]
+                        }
+                    ],
+                    "x-schema-form": {
+                        "hidden": [
+                            {
+                                "$eq": {
+                                    "ssl.trustAll": true
+                                }
+                            }
+                        ]
+                    }
+                },
+                "keyStore": {
+                    "type": "object",
+                    "title": "Key store",
+                    "id": "urn:jsonschema:io:gravitee:connector:http:configuration:SslKeyStoreOptions",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The type of the key store",
+                            "default": "",
+                            "enum": ["", "JKS", "PKCS12", "PEM"],
+                            "x-schema-form": {
+                                "type": "select",
+                                "titleMap": {
+                                    "": "None",
+                                    "JKS": "Java Trust Store (.jks)",
+                                    "PKCS12": "PKCS#12 (.p12) / PFX (.pfx)",
+                                    "PEM": "PEM (.pem)"
+                                }
+                            }
+                        },
+                        "password": {
+                            "type": "string",
+                            "title": "Password",
+                            "description": "Key store password",
+                            "x-schema-form": {
+                                "type": "password",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "path": {
+                            "type": "string",
+                            "title": "Path to key store",
+                            "description": "Path to the key store file",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "content": {
+                            "type": "string",
+                            "title": "Content",
+                            "description": "Binary content as Base64",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$eq": {
+                                            "ssl.keyStore.type": ["", "PEM"]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "certPath": {
+                            "type": "string",
+                            "title": "Path to cert file",
+                            "description": "Path to cert file (.PEM)",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "certContent": {
+                            "type": "string",
+                            "title": "Certificate",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "keyPath": {
+                            "type": "string",
+                            "title": "Path to private key file",
+                            "description": "Path to private key file (.PEM)",
+                            "x-schema-form": {
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "keyContent": {
+                            "type": "string",
+                            "title": "Private key",
+                            "x-schema-form": {
+                                "type": "text",
+                                "hidden": [
+                                    {
+                                        "$neq": {
+                                            "ssl.keyStore.type": "PEM"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "properties": { "type": { "const": "" } }
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certContent", "keyContent"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certPath", "keyPath"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certContent", "keyPath"]
+                        },
+                        {
+                            "properties": { "type": { "const": "PEM" } },
+                            "required": ["certPath", "keyContent"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["content", "password"]
+                        },
+                        {
+                            "properties": { "type": { "pattern": "JKS|PKCS12" } },
+                            "required": ["path", "password"]
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "additionalProperties": false,
+    "patternProperties": {
+        "backup": true,
+        "healthcheck": true,
+        "inherit": true,
+        "name": true,
+        "target": true,
+        "tenants": true,
+        "type": true,
+        "weight": true
+    },
+    "x-schema-form": {
+        "errors": {
+            "proxy": {
+                "oneOf": "The host and port are <span class=\"error\">required</span>"
+            },
+            "ssl": {
+                "trustStore": {
+                    "oneOf": "A path or a content is <span class=\"error\">required</span> - for JKS and PKCS#12 a password is also <span class=\"error\">required</span>"
+                },
+                "keyStore": {
+                    "oneOf": "Paths or contents are <span class=\"error\">required</span> - for JKS and PKCS#12, a password is also <span class=\"error\">required</span>."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Description**

Previously injectOptionalDefaults populated every property carrying a
"default", even when the schema's "required" array did not list it. That
over-filled responses with optional fields the caller deliberately
omitted (hidden form fields, opt-in flags). Now treat presence of
"required" as a signal that non-listed properties are opt-in: only
required defaults are auto-injected. Schemas without "required" keep
the legacy "inject all defaults" behavior.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.2-fix-edge-case-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/json/gravitee-json-validation/3.0.2-fix-edge-case-SNAPSHOT/gravitee-json-validation-3.0.2-fix-edge-case-SNAPSHOT.zip)
  <!-- Version placeholder end -->
